### PR TITLE
Delete items from keychain when key is deleted. [iOS]

### DIFF
--- a/src/ios/KeychainWrapper.h
+++ b/src/ios/KeychainWrapper.h
@@ -14,5 +14,6 @@
 - (void)mySetObject:(id)inObject forKey:(id)key;
 - (id)myObjectForKey:(id)key;
 - (void)writeToKeychain;
+- (void)resetKeychainItem;
 
 @end

--- a/src/ios/TouchID.m
+++ b/src/ios/TouchID.m
@@ -77,6 +77,14 @@
 -(void)delete:(CDVInvokedUrlCommand*)command{
 	 	self.TAG = (NSString*)[command.arguments objectAtIndex:0];
     @try {
+        
+        if(self.TAG && [[NSUserDefaults standardUserDefaults] objectForKey:self.TAG])
+        {
+            self.MyKeychainWrapper = [[KeychainWrapper alloc]init];
+            [self.MyKeychainWrapper resetKeychainItem];
+        }
+        
+
         [[NSUserDefaults standardUserDefaults] removeObjectForKey:self.TAG];
         CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];


### PR DESCRIPTION
Rewrite item from keychain when item is deleted, this is so sensitive values don't remain in keychain even after they aren't needed.