### PR TITLE
Added error returns

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-keychain-touch-id",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "Scan the fingerprint of your user with the TouchID sensor (iPhone 5S, iPhone 6(S), ..) and control a key in the Keychain",
   "cordova": {
     "id": "cordova-plugin-keychain-touch-id",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-keychain-touch-id",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Scan the fingerprint of your user with the TouchID sensor (iPhone 5S, iPhone 6(S), ..) and control a key in the Keychain",
   "cordova": {
     "id": "cordova-plugin-keychain-touch-id",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-keychain-touch-id",
-  "version": "3.2.3",
+  "version": "3.3.0",
   "description": "Scan the fingerprint of your user with the TouchID sensor (iPhone 5S, iPhone 6(S), ..) and control a key in the Keychain",
   "cordova": {
     "id": "cordova-plugin-keychain-touch-id",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-keychain-touch-id",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Scan the fingerprint of your user with the TouchID sensor (iPhone 5S, iPhone 6(S), ..) and control a key in the Keychain",
   "cordova": {
     "id": "cordova-plugin-keychain-touch-id",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-keychain-touch-id",
-  "version": "3.4.0",
+  "version": "3.3.0",
   "description": "Scan the fingerprint of your user with the TouchID sensor (iPhone 5S, iPhone 6(S), ..) and control a key in the Keychain",
   "cordova": {
     "id": "cordova-plugin-keychain-touch-id",

--- a/plugin.xml
+++ b/plugin.xml
@@ -45,6 +45,7 @@
         </config-file>
 
         <source-file src="src/android/FingerprintAuth.java" target-dir="src/com/cordova/plugin/android/fingerprintauth" />
+        <source-file src="src/android/FingerprintAuthAux.java" target-dir="src/com/cordova/plugin/android/fingerprintauth" />
         <source-file src="src/android/FingerprintAuthenticationDialogFragment.java" target-dir="src/com/cordova/plugin/android/fingerprintauth" />
         <source-file src="src/android/FingerprintUiHelper.java" target-dir="src/com/cordova/plugin/android/fingerprintauth" />
         <source-file src="res/android/drawable/ic_fingerprint_error.xml" target-dir="res/drawable" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         id="cordova-plugin-keychain-touch-id"
-		version="3.4.0">
+		version="3.3.0">
     <name>TouchID and Keychain</name>
 	  <author>S.J.Hoeksma</author>
     <description>TouchID and Keychain cordova plugin for iOS</description>

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         id="cordova-plugin-keychain-touch-id"
-		version="3.2.2">
+		version="3.2.3">
     <name>TouchID and Keychain</name>
 	  <author>S.J.Hoeksma</author>
     <description>TouchID and Keychain cordova plugin for iOS</description>

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         id="cordova-plugin-keychain-touch-id"
-		version="3.2.1">
+		version="3.2.2">
     <name>TouchID and Keychain</name>
 	  <author>S.J.Hoeksma</author>
     <description>TouchID and Keychain cordova plugin for iOS</description>

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         id="cordova-plugin-keychain-touch-id"
-		version="3.3.0">
+		version="3.4.0">
     <name>TouchID and Keychain</name>
 	  <author>S.J.Hoeksma</author>
     <description>TouchID and Keychain cordova plugin for iOS</description>

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         id="cordova-plugin-keychain-touch-id"
-		version="3.2.3">
+		version="3.3.0">
     <name>TouchID and Keychain</name>
 	  <author>S.J.Hoeksma</author>
     <description>TouchID and Keychain cordova plugin for iOS</description>

--- a/readme.md
+++ b/readme.md
@@ -64,9 +64,9 @@ if (window.plugins.touchid) {
 
 Call the function you like
 
-**isAvailable(successCallback, errorCallback(msg))** will Check if touchid is available on the used device 	
-	
-**save(key,password, userAuthenticationRequired, successCallback, errorCallback(msg))** 
+**isAvailable(successCallback(biometryType), errorCallback(msg))** will Check if touchid is available on the used device. The `successCallback` gets the `biometryType` argument with 'face' on iPhone X, 'touch' on other devices.
+
+**save(key,password, successCallback, errorCallback(msg))**
 will save a password under the key in the device keychain, which can be retrieved using a fingerprint. 
 userAuthenticationRequired if true will save after authentication with fingerprint, if false there's no need to authenticate to save. Default to true, if not set.
 
@@ -93,15 +93,16 @@ This invalid key is removed - user needs to **save their password again**.
 
 ```js
 if (window.plugins) {
-    window.plugins.touchid.isAvailable(function() {
-        window.plugins.touchid.has("MyKey", function() {
-            alert("Touch ID available and Password key available");
-        }, function() {
-            alert("Touch ID available but no Password Key available");
-        });
-    }, function(msg) {
-        alert("no Touch ID available");
-    });
+window.plugins.touchid.isAvailable(function(biometryType) {
+var serviceName = (biometryType === "face") ? "Face ID" : "Touch ID";
+window.plugins.touchid.has("MyKey", function() {
+alert(serviceName + " avaialble and Password key available");
+}, function() {
+alert(serviceName + " available but no Password Key available");
+});
+}, function(msg) {
+alert("no Touch ID available");
+});
 }
 
 if (window.plugins) {

--- a/readme.md
+++ b/readme.md
@@ -66,8 +66,9 @@ Call the function you like
 
 **isAvailable(successCallback, errorCallback(msg))** will Check if touchid is available on the used device 	
 	
-**save(key,password, successCallback, errorCallback(msg))** 
-will save a password under the key in the device keychain, which can be retrieved using a fingerprint
+**save(key,password, userAuthenticationRequired, successCallback, errorCallback(msg))** 
+will save a password under the key in the device keychain, which can be retrieved using a fingerprint. 
+userAuthenticationRequired if true will save after authentication with fingerprint, if false there's no need to authenticate to save. Default to true, if not set.
 
 **verify(key,message,successCallback(password), errorCallback(errorCode))**
 will open the fingerprint dialog, for the given key, showing an additional message.
@@ -94,7 +95,7 @@ This invalid key is removed - user needs to **save their password again**.
 if (window.plugins) {
     window.plugins.touchid.isAvailable(function() {
         window.plugins.touchid.has("MyKey", function() {
-            alert("Touch ID avaialble and Password key available");
+            alert("Touch ID available and Password key available");
         }, function() {
             alert("Touch ID available but no Password Key available");
         });
@@ -105,12 +106,12 @@ if (window.plugins) {
 
 if (window.plugins) {
     window.plugins.touchid.verify("MyKey", "My Message", function(password) {
-        alert("Tocuh " + password);
+        alert("Touch " + password);
     });
 }
 
 if (window.plugins) {
-    window.plugins.touchid.save("MyKey", "My Password", function() {
+    window.plugins.touchid.save("MyKey", "My Password", true, function() {
         alert("Password saved");
     });
 }

--- a/src/android/FingerprintAuth.java
+++ b/src/android/FingerprintAuth.java
@@ -1,10 +1,5 @@
 package com.cordova.plugin.android.fingerprintauth;
 
-import org.apache.cordova.CordovaWebView;
-import org.apache.cordova.CallbackContext;
-import org.apache.cordova.CordovaPlugin;
-import org.apache.cordova.CordovaInterface;
-
 import android.annotation.TargetApi;
 import android.app.KeyguardManager;
 import android.content.Context;
@@ -19,12 +14,6 @@ import android.security.keystore.KeyProperties;
 import android.util.Base64;
 import android.util.DisplayMetrics;
 import android.util.Log;
-
-import org.apache.cordova.PluginResult;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
-
 import java.io.IOException;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
@@ -37,7 +26,6 @@ import java.security.UnrecoverableEntryException;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
 import java.util.Locale;
-
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
@@ -45,437 +33,479 @@ import javax.crypto.KeyGenerator;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.IvParameterSpec;
+import org.apache.cordova.CallbackContext;
+import org.apache.cordova.CordovaInterface;
+import org.apache.cordova.CordovaPlugin;
+import org.apache.cordova.CordovaWebView;
+import org.apache.cordova.PluginResult;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
 
-@TargetApi(23)
-public class FingerprintAuth extends CordovaPlugin {
+@TargetApi(23) public class FingerprintAuth extends CordovaPlugin {
 
-    public static final String TAG = "FingerprintAuth";
-    public static String packageName;
+  public static final String TAG = "FingerprintAuth";
+  private static final String DIALOG_FRAGMENT_TAG = "FpAuthDialog";
+  private static final String ANDROID_KEY_STORE = "AndroidKeyStore";
+  /**
+   * Alias for our key in the Android Key Store
+   */
+  private final static String mClientId = "CordovaTouchPlugin";
+  public static String packageName;
+  public static KeyStore mKeyStore;
+  public static KeyGenerator mKeyGenerator;
+  public static Cipher mCipher;
+  public static CallbackContext mCallbackContext;
+  public static PluginResult mPluginResult;
+  /**
+   * Used to encrypt token
+   */
+  private static String mKeyID;
+  KeyguardManager mKeyguardManager;
+  FingerprintAuthenticationDialogFragment mFragment;
+  private FingerprintManager mFingerPrintManager;
+  private int mCurrentMode;
+  private String mLangCode = "en_US";
+  /**
+   * String to encrypt
+   */
+  private String mToEncrypt;
 
-    private static final String DIALOG_FRAGMENT_TAG = "FpAuthDialog";
-    private static final String ANDROID_KEY_STORE = "AndroidKeyStore";
+  /**
+   * Constructor.
+   */
+  public FingerprintAuth() {
+  }
 
-    KeyguardManager mKeyguardManager;
-    FingerprintAuthenticationDialogFragment mFragment;
-    public static KeyStore mKeyStore;
-    public static KeyGenerator mKeyGenerator;
-    public static Cipher mCipher;
-    private FingerprintManager mFingerPrintManager;
-    private int mCurrentMode;
+  /**
+   * Creates a symmetric key in the Android Key Store which can only be used after the user has
+   * authenticated with fingerprint.
+   */
+  public static boolean createKey() {
+    String errorMessage = "";
+    String createKeyExceptionErrorPrefix = "Failed to create key: ";
+    boolean isKeyCreated = false;
+    // The enrolling flow for fingerprint. This is where you ask the user to set up fingerprint
+    // for your flow. Use of keys is necessary if you need to know if the set of
+    // enrolled fingerprints has changed.
+    try {
+      mKeyStore.load(null);
+      // Set the alias of the entry in Android KeyStore where the key will appear
+      // and the constrains (purposes) in the constructor of the Builder
+      mKeyGenerator.init(new KeyGenParameterSpec.Builder(mClientId,
+          KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT).setBlockModes(
+          KeyProperties.BLOCK_MODE_CBC)
+          // Require the user to authenticate with a fingerprint to authorize every use
+          // of the key
+          .setUserAuthenticationRequired(false)
+          .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_PKCS7)
+          .build());
+      mKeyGenerator.generateKey();
+      isKeyCreated = true;
+    } catch (NoSuchAlgorithmException e) {
+      errorMessage = createKeyExceptionErrorPrefix + "NoSuchAlgorithmException";
+    } catch (InvalidAlgorithmParameterException e) {
+      errorMessage = createKeyExceptionErrorPrefix + "InvalidAlgorithmParameterException";
+    } catch (CertificateException e) {
+      errorMessage = createKeyExceptionErrorPrefix + "CertificateException";
+    } catch (IOException e) {
+      errorMessage = createKeyExceptionErrorPrefix + "IOException";
+    }
+    if (!isKeyCreated) {
+      Log.e(TAG, errorMessage);
+      setPluginResultError(errorMessage);
+    }
+    return isKeyCreated;
+  }
 
-    public static CallbackContext mCallbackContext;
-    public static PluginResult mPluginResult;
+  public static void onCancelled() {
+    mCallbackContext.error("Cancelled");
+  }
 
-    /**
-     * Alias for our key in the Android Key Store
-     */
-    private final static String mClientId = "CordovaTouchPlugin";
-    /**
-     * Used to encrypt token
-     */
-    private static String mKeyID;
+  public static boolean setPluginResultError(String errorMessage) {
+    mCallbackContext.error(errorMessage);
+    mPluginResult = new PluginResult(PluginResult.Status.ERROR);
+    return false;
+  }
 
-    private String mLangCode = "en_US";
-    /**
-     * String to encrypt
-     */
-    private String mToEncrypt;
+  /**
+   * Sets the context of the Command. This can then be used to do things like
+   * get file paths associated with the Activity.
+   *
+   * @param cordova The context of the main Activity.
+   * @param webView The CordovaWebView Cordova is running in.
+   */
 
-    /**
-     * Constructor.
-     */
-    public FingerprintAuth() {
+  public void initialize(CordovaInterface cordova, CordovaWebView webView) {
+    super.initialize(cordova, webView);
+    Log.v(TAG, "Init FingerprintAuth");
+    packageName = cordova.getActivity().getApplicationContext().getPackageName();
+    mPluginResult = new PluginResult(PluginResult.Status.NO_RESULT);
+
+    if (android.os.Build.VERSION.SDK_INT < 23) {
+      return;
     }
 
-    /**
-     * Sets the context of the Command. This can then be used to do things like
-     * get file paths associated with the Activity.
-     *
-     * @param cordova The context of the main Activity.
-     * @param webView The CordovaWebView Cordova is running in.
-     */
+    mKeyguardManager = cordova.getActivity().getSystemService(KeyguardManager.class);
+    mFingerPrintManager =
+        cordova.getActivity().getApplicationContext().getSystemService(FingerprintManager.class);
 
-    public void initialize(CordovaInterface cordova, CordovaWebView webView) {
-        super.initialize(cordova, webView);
-        Log.v(TAG, "Init FingerprintAuth");
-        packageName = cordova.getActivity().getApplicationContext().getPackageName();
-        mPluginResult = new PluginResult(PluginResult.Status.NO_RESULT);
-
-        if (android.os.Build.VERSION.SDK_INT < 23) {
-            return;
-        }
-
-        mKeyguardManager = cordova.getActivity().getSystemService(KeyguardManager.class);
-        mFingerPrintManager = cordova.getActivity().getApplicationContext()
-                .getSystemService(FingerprintManager.class);
-
-        try {
-            mKeyGenerator = KeyGenerator.getInstance(
-                    KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEY_STORE);
-            mKeyStore = KeyStore.getInstance(ANDROID_KEY_STORE);
-
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException("Failed to get an instance of KeyGenerator", e);
-        } catch (NoSuchProviderException e) {
-            throw new RuntimeException("Failed to get an instance of KeyGenerator", e);
-        } catch (KeyStoreException e) {
-            throw new RuntimeException("Failed to get an instance of KeyStore", e);
-        }
-
-        try {
-            mCipher = Cipher.getInstance(KeyProperties.KEY_ALGORITHM_AES + "/"
-                    + KeyProperties.BLOCK_MODE_CBC + "/"
-                    + KeyProperties.ENCRYPTION_PADDING_PKCS7);
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException("Failed to get an instance of Cipher", e);
-        } catch (NoSuchPaddingException e) {
-            throw new RuntimeException("Failed to get an instance of Cipher", e);
-        }
+    try {
+      mKeyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEY_STORE);
+      mKeyStore = KeyStore.getInstance(ANDROID_KEY_STORE);
+    } catch (NoSuchAlgorithmException e) {
+      throw new RuntimeException("Failed to get an instance of KeyGenerator", e);
+    } catch (NoSuchProviderException e) {
+      throw new RuntimeException("Failed to get an instance of KeyGenerator", e);
+    } catch (KeyStoreException e) {
+      throw new RuntimeException("Failed to get an instance of KeyStore", e);
     }
 
-    /**
-     * Executes the request and returns PluginResult.
-     *
-     * @param action          The action to execute.
-     * @param args            JSONArry of arguments for the plugin.
-     * @param callbackContext The callback id used when calling back into JavaScript.
-     * @return A PluginResult object with a status and message.
-     */
-    public boolean execute(final String action,
-                           JSONArray args,
-                           CallbackContext callbackContext) throws JSONException {
-        mCallbackContext = callbackContext;
-        Log.v(TAG, "FingerprintAuth action: " + action);
-        if (android.os.Build.VERSION.SDK_INT < 23) {
-            Log.e(TAG, "minimum SDK version 23 required");
-            mPluginResult = new PluginResult(PluginResult.Status.ERROR);
-            mCallbackContext.error("minimum SDK version 23 required");
-            mCallbackContext.sendPluginResult(mPluginResult);
-            return true;
-        }
-        if (action.equals("save")) {
-            final String key = args.getString(0);
-            final String password = args.getString(1);
-
-            if (isFingerprintAuthAvailable()) {
-                SecretKey secretKey = getSecretKey();
-                boolean isCipherInit = true;
-                if (secretKey == null) {
-                    if (createKey()) {
-                        secretKey = getSecretKey();
-                    }
-                }
-                mKeyID = key;
-                mToEncrypt = password;
-                showFingerprintDialog(Cipher.ENCRYPT_MODE,null);
-
-                return true;
-            } else {
-                mPluginResult = new PluginResult(PluginResult.Status.ERROR);
-                mCallbackContext.error("Fingerprint authentication not available");
-                mCallbackContext.sendPluginResult(mPluginResult);
-            }
-            return true;
-        } else if (action.equals("verify")) {
-            final String key = args.getString(0);
-            final String message = args.getString(1);
-
-            if (isFingerprintAuthAvailable()) {
-                SecretKey secretKey = getSecretKey();
-
-                if (secretKey != null) {
-                    mKeyID = key;
-                    showFingerprintDialog(Cipher.DECRYPT_MODE,message);
-                    mPluginResult.setKeepCallback(true);
-                } else {
-                    mPluginResult = new PluginResult(PluginResult.Status.ERROR);
-                    mCallbackContext.error("Secret Key non available");
-                    mCallbackContext.sendPluginResult(mPluginResult);
-                }
-
-            } else {
-                mPluginResult = new PluginResult(PluginResult.Status.ERROR);
-                mCallbackContext.error("Fingerprint authentication not available");
-                mCallbackContext.sendPluginResult(mPluginResult);
-            }
-            return true;
-        }  else if (action.equals("isAvailable")) {
-            JSONObject resultJson = new JSONObject();
-            if (isFingerprintAuthAvailable()) {
-                mPluginResult = new PluginResult(PluginResult.Status.OK);
-                mCallbackContext.success("YES");
-                mCallbackContext.sendPluginResult(mPluginResult);
-            } else {
-                mPluginResult = new PluginResult(PluginResult.Status.ERROR);
-                mCallbackContext.error("No FP availabile");
-                mCallbackContext.sendPluginResult(mPluginResult);
-            }
-            return true;
-        } else if (action.equals("setLocale")) {            // Set language
-            mLangCode = args.getString(0);
-            Resources res = cordova.getActivity().getResources();
-            // Change locale settings in the app.
-            DisplayMetrics dm = res.getDisplayMetrics();
-            Configuration conf = res.getConfiguration();
-            conf.locale = new Locale(mLangCode.toLowerCase());
-            res.updateConfiguration(conf, dm);
-            return true;
-        }else if (action.equals("has")) { //if has key
-            String key = args.getString(0);
-            SharedPreferences sharedPref = cordova.getActivity().getPreferences(Context.MODE_PRIVATE);
-            String enc = sharedPref.getString("fing" + key, "");
-            if(!enc.equals("")){
-                mPluginResult = new PluginResult(PluginResult.Status.OK);
-                mCallbackContext.success();
-                mCallbackContext.sendPluginResult(mPluginResult);
-            } else {
-                mPluginResult = new PluginResult(PluginResult.Status.ERROR);
-                mCallbackContext.error("No pw available");
-                mCallbackContext.sendPluginResult(mPluginResult);
-            }
-            return true;
-        } else if (action.equals("delete")) { //delete key
-            final String key = args.getString(0);
-            SharedPreferences sharedPref = cordova.getActivity().getPreferences(Context.MODE_PRIVATE);
-            SharedPreferences.Editor editor = sharedPref.edit();
-            editor.remove("fing"+ key);
-            editor.remove("fing_iv"+ key);
-            boolean removed = editor.commit();
-            if (removed) {
-                mPluginResult = new PluginResult(PluginResult.Status.OK);
-                mCallbackContext.success();
-            } else {
-                mPluginResult = new PluginResult(PluginResult.Status.ERROR);
-                mCallbackContext.error("Could not delete password");
-            }
-            mCallbackContext.sendPluginResult(mPluginResult);
-            return true;
-        }
-        return false;
+    try {
+      mCipher = Cipher.getInstance(KeyProperties.KEY_ALGORITHM_AES
+          + "/"
+          + KeyProperties.BLOCK_MODE_CBC
+          + "/"
+          + KeyProperties.ENCRYPTION_PADDING_PKCS7);
+    } catch (NoSuchAlgorithmException e) {
+      throw new RuntimeException("Failed to get an instance of Cipher", e);
+    } catch (NoSuchPaddingException e) {
+      throw new RuntimeException("Failed to get an instance of Cipher", e);
     }
+  }
 
-    private boolean isFingerprintAuthAvailable() {
-        return mFingerPrintManager.isHardwareDetected() && mFingerPrintManager.hasEnrolledFingerprints();
+  /**
+   * Executes the request and returns PluginResult.
+   *
+   * @param action The action to execute.
+   * @param args JSONArry of arguments for the plugin.
+   * @param callbackContext The callback id used when calling back into JavaScript.
+   * @return A PluginResult object with a status and message.
+   */
+  public boolean execute(final String action, JSONArray args, CallbackContext callbackContext)
+      throws JSONException {
+    mCallbackContext = callbackContext;
+    Log.v(TAG, "FingerprintAuth action: " + action);
+    if (android.os.Build.VERSION.SDK_INT < 23) {
+      Log.e(TAG, "minimum SDK version 23 required");
+      JSONObject resultJson = new JSONObject();
+      resultJson.put("OS", "Android");
+      resultJson.put("ErrorCode", "-6");
+      resultJson.put("ErrorMessage", "Biometry is not available on this device.");
+      mPluginResult = new PluginResult(PluginResult.Status.ERROR);
+      mCallbackContext.error(resultJson.toString());
+      mCallbackContext.sendPluginResult(mPluginResult);
+      return true;
     }
+    if (action.equals("save")) {
+      final String key = args.getString(0);
+      final String password = args.getString(1);
 
-    /**
-     * Initialize the {@link Cipher} instance with the created key in the {@link #createKey()}
-     * method.
-     *
-     * @return {@code true} if initialization is successful, {@code false} if the lock screen has
-     * been disabled or reset after the key was generated, or if a fingerprint got enrolled after
-     * the key was generated.
-     */
-    private boolean initCipher(int mode) {
-        boolean initCipher = false;
-        String errorMessage = "";
-        String initCipherExceptionErrorPrefix = "Failed to init Cipher: ";
-        try {
-            SecretKey key = getSecretKey();
-
-            if ( mode== Cipher.ENCRYPT_MODE){
-                SecureRandom r = new SecureRandom();
-                byte[] ivBytes = new byte[16];
-                r.nextBytes(ivBytes);
-
-                mCipher.init(mode, key);
-            }else {
-                SharedPreferences sharedPref = cordova.getActivity().getPreferences(Context.MODE_PRIVATE);
-                byte[] ivBytes = Base64.decode(sharedPref.getString("fing_iv" + mKeyID, ""),Base64.DEFAULT);
-
-                mCipher.init(mode, key,new IvParameterSpec(ivBytes));
-            }
-
-            initCipher = true;
-        } catch (KeyPermanentlyInvalidatedException e) {
-            removePermanentlyInvalidatedKey();
-            errorMessage = "KeyPermanentlyInvalidatedException";
-            setPluginResultError(errorMessage);
-        } catch (InvalidKeyException e) {
-            errorMessage = initCipherExceptionErrorPrefix
-                    + "InvalidKeyException";
-        } catch (InvalidAlgorithmParameterException e) {
-            errorMessage = initCipherExceptionErrorPrefix
-                    + "InvalidAlgorithmParameterException";
-            e.printStackTrace();
+      if (isFingerprintAuthAvailable()) {
+        SecretKey secretKey = getSecretKey();
+        boolean isCipherInit = true;
+        if (secretKey == null) {
+          if (createKey()) {
+            secretKey = getSecretKey();
+          }
         }
-        if (!initCipher) {
-            Log.e(TAG, errorMessage);
-        }
-        return initCipher;
-    }
+        mKeyID = key;
+        mToEncrypt = password;
+        SharedPreferences sharedPref = cordova.getActivity().getPreferences(Context.MODE_PRIVATE);
+        SharedPreferences.Editor editor = sharedPref.edit();
+        if (initCipher(Cipher.ENCRYPT_MODE)) {
+          byte[] enc = new byte[0];
+          try {
+            enc = mCipher.doFinal(mToEncrypt.getBytes());
 
-    private SecretKey getSecretKey() {
-        String errorMessage = "";
-        String getSecretKeyExceptionErrorPrefix = "Failed to get SecretKey from KeyStore: ";
-        SecretKey key = null;
-        try {
-            mKeyStore.load(null);
-            key = (SecretKey) mKeyStore.getKey(mClientId, null);
-        } catch (KeyStoreException e) {
-            errorMessage = getSecretKeyExceptionErrorPrefix
-                    + "KeyStoreException";
-        } catch (CertificateException e) {
-            errorMessage = getSecretKeyExceptionErrorPrefix
-                    + "CertificateException";
-        } catch (UnrecoverableKeyException e) {
-            errorMessage = getSecretKeyExceptionErrorPrefix
-                    + "UnrecoverableKeyException";
-        } catch (IOException e) {
-            errorMessage = getSecretKeyExceptionErrorPrefix
-                    + "IOException";
-        } catch (NoSuchAlgorithmException e) {
-            errorMessage = getSecretKeyExceptionErrorPrefix
-                    + "NoSuchAlgorithmException";
-        } catch (UnrecoverableEntryException e) {
-            errorMessage = getSecretKeyExceptionErrorPrefix
-                    + "UnrecoverableEntryException";
-        }
-        if (key == null) {
-            Log.e(TAG, errorMessage);
-        }
-        return key;
-    }
+            editor.putString("fing" + mKeyID, Base64.encodeToString(enc, Base64.DEFAULT));
+            editor.putString("fing_iv" + mKeyID, Base64.encodeToString(mCipher.getIV(), Base64.DEFAULT));
 
-    /**
-     * Creates a symmetric key in the Android Key Store which can only be used after the user has
-     * authenticated with fingerprint.
-     */
-    public static boolean createKey() {
-        String errorMessage = "";
-        String createKeyExceptionErrorPrefix = "Failed to create key: ";
-        boolean isKeyCreated = false;
-        // The enrolling flow for fingerprint. This is where you ask the user to set up fingerprint
-        // for your flow. Use of keys is necessary if you need to know if the set of
-        // enrolled fingerprints has changed.
-        try {
-            mKeyStore.load(null);
-            // Set the alias of the entry in Android KeyStore where the key will appear
-            // and the constrains (purposes) in the constructor of the Builder
-            mKeyGenerator.init(new KeyGenParameterSpec.Builder(mClientId,
-                    KeyProperties.PURPOSE_ENCRYPT |
-                            KeyProperties.PURPOSE_DECRYPT)
-                    .setBlockModes(KeyProperties.BLOCK_MODE_CBC)
-                    // Require the user to authenticate with a fingerprint to authorize every use
-                    // of the key
-                    .setUserAuthenticationRequired(true)
-                    .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_PKCS7)
-                    .build());
-            mKeyGenerator.generateKey();
-            isKeyCreated = true;
-        } catch (NoSuchAlgorithmException e) {
-            errorMessage = createKeyExceptionErrorPrefix
-                    + "NoSuchAlgorithmException";
-        } catch (InvalidAlgorithmParameterException e) {
-            errorMessage = createKeyExceptionErrorPrefix
-                    + "InvalidAlgorithmParameterException";
-        } catch (CertificateException e) {
-            errorMessage = createKeyExceptionErrorPrefix
-                    + "CertificateException";
-        } catch (IOException e) {
-            errorMessage = createKeyExceptionErrorPrefix
-                    + "IOException";
-        }
-        if (!isKeyCreated) {
-            Log.e(TAG, errorMessage);
-            setPluginResultError(errorMessage);
-        }
-        return isKeyCreated;
-    }
-
-    public void showFingerprintDialog(final int mode, final String message){
-        final FingerprintAuth auth = this;
-        mCurrentMode = mode;
-        cordova.getActivity().runOnUiThread(new Runnable() {
-            public void run() {
-                // Set up the crypto object for later. The object will be authenticated by use
-                // of the fingerprint.
-                mFragment = new FingerprintAuthenticationDialogFragment();
-                Bundle bundle = new Bundle();
-                bundle.putInt("dialogMode", mode);
-                bundle.putString("dialogMessage",message);
-                mFragment.setArguments(bundle);
-                mFragment.setmFingerPrintAuth(auth);
-
-                if (initCipher(mode)) {
-                    mFragment.setCancelable(false);
-                    // Show the fingerprint dialog. The user has the option to use the fingerprint with
-                    // crypto, or you can fall back to using a server-side verified password.
-                    mFragment.setCryptoObject(new FingerprintManager.CryptoObject(mCipher));
-                    mFragment.show(cordova.getActivity()
-                            .getFragmentManager(), DIALOG_FRAGMENT_TAG);
-                } else {
-                    mCallbackContext.error("Failed to init Cipher");
-                    mPluginResult = new PluginResult(PluginResult.Status.ERROR);
-                    mCallbackContext.sendPluginResult(mPluginResult);
-                }
-            }
-        });
-    }
-
-    public  void onAuthenticated(boolean withFingerprint) {
-        String result = "";
-        String errorMessage = "";
-        try {
-
-            if (withFingerprint) {
-                // If the user has authenticated with fingerprint, verify that using cryptography and
-                // then return the encrypted token
-                SharedPreferences sharedPref = cordova.getActivity().getPreferences(Context.MODE_PRIVATE);
-                if(mCurrentMode == Cipher.DECRYPT_MODE){
-                    byte[] enc = Base64.decode(sharedPref.getString("fing" + mKeyID, ""),Base64.DEFAULT);
-
-                    byte[] decrypted = mCipher.doFinal(enc);
-                    String decrString = new String(decrypted);
-                    result = decrString;
-                } else if (mCurrentMode == Cipher.ENCRYPT_MODE){
-                    SharedPreferences.Editor editor = sharedPref.edit();
-
-                    byte[] enc = mCipher.doFinal(mToEncrypt.getBytes());
-                    editor.putString("fing"+ mKeyID,Base64.encodeToString(enc, Base64.DEFAULT));
-                    editor.putString("fing_iv"+ mKeyID,Base64.encodeToString(mCipher.getIV(), Base64.DEFAULT));
-
-                    editor.commit();
-                    mToEncrypt = "";
-                    result = "success";
-                }
-            }
-        } catch (BadPaddingException e) {
-            errorMessage = "Failed to encrypt the data with the generated key:" +
-                    " BadPaddingException:  " + e.getMessage();
-            Log.e(TAG, errorMessage);
-        } catch (IllegalBlockSizeException e) {
-            errorMessage = "Failed to encrypt the data with the generated key: " +
-                    "IllegalBlockSizeException: " + e.getMessage();
-            Log.e(TAG, errorMessage);
-        }
-
-        if (result != "") {
-            mCallbackContext.success(result);
+            editor.apply();
+            mCallbackContext.success("Success");
             mPluginResult = new PluginResult(PluginResult.Status.OK);
-        } else {
-            mCallbackContext.error(errorMessage);
+            mCallbackContext.sendPluginResult(mPluginResult);
+            return true;
+          } catch (IllegalBlockSizeException e) {
+            e.printStackTrace();
+            mCallbackContext.success("Error string is to big.");
             mPluginResult = new PluginResult(PluginResult.Status.ERROR);
+            mCallbackContext.sendPluginResult(mPluginResult);
+          } catch (BadPaddingException e) {
+            e.printStackTrace();
+            mCallbackContext.success("Error Bad Padding");
+            mPluginResult = new PluginResult(PluginResult.Status.ERROR);
+            mCallbackContext.sendPluginResult(mPluginResult);
+          }
         }
-        mCallbackContext.sendPluginResult(mPluginResult);
-    }
-
-    public static void onCancelled() {
-        mCallbackContext.error("Cancelled");
-    }
-
-    public static boolean setPluginResultError(String errorMessage) {
-        mCallbackContext.error(errorMessage);
+      } else {
+        mCallbackContext.error("Fingerprint authentication not available");
         mPluginResult = new PluginResult(PluginResult.Status.ERROR);
-        return false;
+        mCallbackContext.sendPluginResult(mPluginResult);
+      }
+      return true;
+    } else if (action.equals("verify")) {
+      final String key = args.getString(0);
+      final String message = args.getString(1);
+
+      JSONObject resultJson = new JSONObject();
+      resultJson.put("OS", "Android");
+
+      if (isHardwareDetected()) {
+        if (hasEnrolledFingerprints()){
+          SecretKey secretKey = getSecretKey();
+          if (secretKey != null) {
+            mKeyID = key;
+            showFingerprintDialog(Cipher.DECRYPT_MODE, message);
+            mPluginResult.setKeepCallback(true);
+          } else {
+            mPluginResult = new PluginResult(PluginResult.Status.ERROR);
+            resultJson.put("ErrorCode", "-5");
+            resultJson.put("ErrorMessage", "Secret Key not set.");
+            mCallbackContext.error(resultJson.toString());
+            mCallbackContext.sendPluginResult(mPluginResult);
+          }
+        }
+        else{
+          resultJson.put("ErrorCode", "-7");
+          resultJson.put("ErrorMessage", "No fingers are enrolled with Touch ID.");
+          mPluginResult = new PluginResult(PluginResult.Status.ERROR);
+          mCallbackContext.error(resultJson.toString());
+          mCallbackContext.sendPluginResult(mPluginResult);
+        }
+      } else {
+        resultJson.put("ErrorCode", "-6");
+        resultJson.put("ErrorMessage", "Biometry is not available on this device.");
+        mPluginResult = new PluginResult(PluginResult.Status.ERROR);
+        mCallbackContext.error(resultJson.toString());
+        mCallbackContext.sendPluginResult(mPluginResult);
+      }
+      return true;
+    } else if (action.equals("isAvailable")) {
+      JSONObject resultJson = new JSONObject();
+      resultJson.put("OS", "Android");
+      if (isHardwareDetected()) {
+        if (hasEnrolledFingerprints()){
+
+          mPluginResult = new PluginResult(PluginResult.Status.OK);
+          mCallbackContext.success("YES");
+          mCallbackContext.sendPluginResult(mPluginResult);
+        }
+        else{
+          resultJson.put("ErrorCode", "-7");
+          resultJson.put("ErrorMessage", "No fingers are enrolled with Touch ID.");
+          mPluginResult = new PluginResult(PluginResult.Status.ERROR);
+          mCallbackContext.error(resultJson.toString());
+          mCallbackContext.sendPluginResult(mPluginResult);
+        }
+      } else {
+        resultJson.put("ErrorCode", "-6");
+        resultJson.put("ErrorMessage", "Biometry is not available on this device.");
+        mPluginResult = new PluginResult(PluginResult.Status.ERROR);
+        mCallbackContext.error(resultJson.toString());
+        mCallbackContext.sendPluginResult(mPluginResult);
+      }
+      return true;
+    } else if (action.equals("setLocale")) {            // Set language
+      mLangCode = args.getString(0);
+      Resources res = cordova.getActivity().getResources();
+      // Change locale settings in the app.
+      DisplayMetrics dm = res.getDisplayMetrics();
+      Configuration conf = res.getConfiguration();
+      conf.locale = new Locale(mLangCode.toLowerCase());
+      res.updateConfiguration(conf, dm);
+      return true;
+    } else if (action.equals("has")) { //if has key
+      String key = args.getString(0);
+      SharedPreferences sharedPref = cordova.getActivity().getPreferences(Context.MODE_PRIVATE);
+      String enc = sharedPref.getString("fing" + key, "");
+      if (!enc.equals("")) {
+        mPluginResult = new PluginResult(PluginResult.Status.OK);
+        mCallbackContext.success();
+        mCallbackContext.sendPluginResult(mPluginResult);
+      } else {
+        mPluginResult = new PluginResult(PluginResult.Status.ERROR);
+        mCallbackContext.error("No pw available");
+        mCallbackContext.sendPluginResult(mPluginResult);
+      }
+      return true;
+    } else if (action.equals("delete")) { //delete key
+      final String key = args.getString(0);
+      SharedPreferences sharedPref = cordova.getActivity().getPreferences(Context.MODE_PRIVATE);
+      SharedPreferences.Editor editor = sharedPref.edit();
+      editor.remove("fing" + key);
+      editor.remove("fing_iv" + key);
+      boolean removed = editor.commit();
+      if (removed) {
+        mPluginResult = new PluginResult(PluginResult.Status.OK);
+        mCallbackContext.success();
+      } else {
+        mPluginResult = new PluginResult(PluginResult.Status.ERROR);
+        mCallbackContext.error("Could not delete password");
+      }
+      mCallbackContext.sendPluginResult(mPluginResult);
+      return true;
+    }
+    return false;
+  }
+
+  private boolean isFingerprintAuthAvailable() {
+    return isHardwareDetected()
+        && hasEnrolledFingerprints();
+  }
+
+  private boolean isHardwareDetected() {
+    return mFingerPrintManager.isHardwareDetected();
+  }
+
+  private boolean hasEnrolledFingerprints() {
+    return mFingerPrintManager.hasEnrolledFingerprints();
+  }
+
+  /**
+   * Initialize the {@link Cipher} instance with the created key in the {@link #createKey()}
+   * method.
+   *
+   * @return {@code true} if initialization is successful, {@code false} if the lock screen has
+   * been disabled or reset after the key was generated, or if a fingerprint got enrolled after
+   * the key was generated.
+   */
+  private boolean initCipher(int mode) {
+    boolean initCipher = false;
+    String errorMessage = "";
+    String initCipherExceptionErrorPrefix = "Failed to init Cipher: ";
+    try {
+      SecretKey key = getSecretKey();
+
+      if (mode == Cipher.ENCRYPT_MODE) {
+        SecureRandom r = new SecureRandom();
+        byte[] ivBytes = new byte[16];
+        r.nextBytes(ivBytes);
+
+        mCipher.init(mode, key);
+      } else {
+        SharedPreferences sharedPref = cordova.getActivity().getPreferences(Context.MODE_PRIVATE);
+        byte[] ivBytes =
+            Base64.decode(sharedPref.getString("fing_iv" + mKeyID, ""), Base64.DEFAULT);
+
+        mCipher.init(mode, key, new IvParameterSpec(ivBytes));
+      }
+
+      initCipher = true;
+    } catch (KeyPermanentlyInvalidatedException e) {
+      removePermanentlyInvalidatedKey();
+      errorMessage = "KeyPermanentlyInvalidatedException";
+      setPluginResultError(errorMessage);
+    } catch (InvalidKeyException e) {
+      errorMessage = initCipherExceptionErrorPrefix + "InvalidKeyException";
+    } catch (InvalidAlgorithmParameterException e) {
+      errorMessage = initCipherExceptionErrorPrefix + "InvalidAlgorithmParameterException";
+      e.printStackTrace();
+    }
+    if (!initCipher) {
+      Log.e(TAG, errorMessage);
+    }
+    return initCipher;
+  }
+
+  private SecretKey getSecretKey() {
+    String errorMessage = "";
+    String getSecretKeyExceptionErrorPrefix = "Failed to get SecretKey from KeyStore: ";
+    SecretKey key = null;
+    try {
+      mKeyStore.load(null);
+      key = (SecretKey) mKeyStore.getKey(mClientId, null);
+    } catch (KeyStoreException e) {
+      errorMessage = getSecretKeyExceptionErrorPrefix + "KeyStoreException";
+    } catch (CertificateException e) {
+      errorMessage = getSecretKeyExceptionErrorPrefix + "CertificateException";
+    } catch (UnrecoverableKeyException e) {
+      errorMessage = getSecretKeyExceptionErrorPrefix + "UnrecoverableKeyException";
+    } catch (IOException e) {
+      errorMessage = getSecretKeyExceptionErrorPrefix + "IOException";
+    } catch (NoSuchAlgorithmException e) {
+      errorMessage = getSecretKeyExceptionErrorPrefix + "NoSuchAlgorithmException";
+    } catch (UnrecoverableEntryException e) {
+      errorMessage = getSecretKeyExceptionErrorPrefix + "UnrecoverableEntryException";
+    }
+    if (key == null) {
+      Log.e(TAG, errorMessage);
+    }
+    return key;
+  }
+
+  public void showFingerprintDialog(final int mode, final String message) {
+    final FingerprintAuth auth = this;
+    mCurrentMode = mode;
+    cordova.getActivity().runOnUiThread(new Runnable() {
+      public void run() {
+        // Set up the crypto object for later. The object will be authenticated by use
+        // of the fingerprint.
+        mFragment = new FingerprintAuthenticationDialogFragment();
+        Bundle bundle = new Bundle();
+        bundle.putInt("dialogMode", mode);
+        bundle.putString("dialogMessage", message);
+        mFragment.setArguments(bundle);
+        mFragment.setmFingerPrintAuth(auth);
+
+        if (initCipher(mode)) {
+          mFragment.setCancelable(false);
+          // Show the fingerprint dialog. The user has the option to use the fingerprint with
+          // crypto, or you can fall back to using a server-side verified password.
+          mFragment.setCryptoObject(new FingerprintManager.CryptoObject(mCipher));
+          mFragment.show(cordova.getActivity().getFragmentManager(), DIALOG_FRAGMENT_TAG);
+        } else {
+          mCallbackContext.error("Failed to init Cipher");
+          mPluginResult = new PluginResult(PluginResult.Status.ERROR);
+          mCallbackContext.sendPluginResult(mPluginResult);
+        }
+      }
+    });
+  }
+
+  public void onAuthenticated(boolean withFingerprint) {
+    String result = "";
+    String errorMessage = "";
+    try {
+
+      if (withFingerprint) {
+        // If the user has authenticated with fingerprint, verify that using cryptography and
+        // then return the encrypted token
+        SharedPreferences sharedPref = cordova.getActivity().getPreferences(Context.MODE_PRIVATE);
+        if (mCurrentMode == Cipher.DECRYPT_MODE) {
+          byte[] enc = Base64.decode(sharedPref.getString("fing" + mKeyID, ""), Base64.DEFAULT);
+
+          byte[] decrypted = mCipher.doFinal(enc);
+          String decrString = new String(decrypted);
+          result = decrString;
+        }
+      }
+    } catch (BadPaddingException e) {
+      errorMessage = "Failed to encrypt the data with the generated key:" +
+          " BadPaddingException:  " + e.getMessage();
+      Log.e(TAG, errorMessage);
+    } catch (IllegalBlockSizeException e) {
+      errorMessage = "Failed to encrypt the data with the generated key: " +
+          "IllegalBlockSizeException: " + e.getMessage();
+      Log.e(TAG, errorMessage);
     }
 
-    private void removePermanentlyInvalidatedKey() {
-        try {
-            mKeyStore.deleteEntry(mClientId);
-            Log.i(TAG, "Permanently invalidated key was removed.");
-        } catch (KeyStoreException e) {
-            Log.e(TAG, e.getMessage());
-        }
+    if (result != "") {
+      mCallbackContext.success(result);
+      mPluginResult = new PluginResult(PluginResult.Status.OK);
+    } else {
+      mCallbackContext.error(errorMessage);
+      mPluginResult = new PluginResult(PluginResult.Status.ERROR);
     }
+    mCallbackContext.sendPluginResult(mPluginResult);
+  }
+
+  private void removePermanentlyInvalidatedKey() {
+    try {
+      mKeyStore.deleteEntry(mClientId);
+      Log.i(TAG, "Permanently invalidated key was removed.");
+    } catch (KeyStoreException e) {
+      Log.e(TAG, e.getMessage());
+    }
+  }
 }

--- a/src/android/FingerprintAuth.java
+++ b/src/android/FingerprintAuth.java
@@ -80,6 +80,8 @@ import org.json.JSONObject;
   public boolean execute(final String action, JSONArray args, CallbackContext callbackContext)
       throws JSONException {
 
+    mCallbackContext = callbackContext;
+          
     if (android.os.Build.VERSION.SDK_INT < 23) {
       String errorMessage = createErrorMessage(NO_HARDWARE_CODE, NO_HARDWARE_MESSAGE);
       mPluginResult = new PluginResult(PluginResult.Status.ERROR, errorMessage);

--- a/src/android/FingerprintAuth.java
+++ b/src/android/FingerprintAuth.java
@@ -1,38 +1,7 @@
 package com.cordova.plugin.android.fingerprintauth;
 
 import android.annotation.TargetApi;
-import android.app.KeyguardManager;
-import android.content.Context;
-import android.content.SharedPreferences;
-import android.content.res.Configuration;
-import android.content.res.Resources;
-import android.hardware.fingerprint.FingerprintManager;
-import android.os.Bundle;
-import android.security.keystore.KeyGenParameterSpec;
-import android.security.keystore.KeyPermanentlyInvalidatedException;
-import android.security.keystore.KeyProperties;
-import android.util.Base64;
-import android.util.DisplayMetrics;
 import android.util.Log;
-import java.io.IOException;
-import java.security.InvalidAlgorithmParameterException;
-import java.security.InvalidKeyException;
-import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
-import java.security.SecureRandom;
-import java.security.UnrecoverableEntryException;
-import java.security.UnrecoverableKeyException;
-import java.security.cert.CertificateException;
-import java.util.Locale;
-import javax.crypto.BadPaddingException;
-import javax.crypto.Cipher;
-import javax.crypto.IllegalBlockSizeException;
-import javax.crypto.KeyGenerator;
-import javax.crypto.NoSuchPaddingException;
-import javax.crypto.SecretKey;
-import javax.crypto.spec.IvParameterSpec;
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaInterface;
 import org.apache.cordova.CordovaPlugin;
@@ -44,115 +13,34 @@ import org.json.JSONObject;
 
 @TargetApi(23) public class FingerprintAuth extends CordovaPlugin {
 
-  public static final String TAG = "FingerprintAuth";
-  private static final String DIALOG_FRAGMENT_TAG = "FpAuthDialog";
-  private static final String ANDROID_KEY_STORE = "AndroidKeyStore";
 
+  public static final String TAG = "FingerprintAuth";
   // Plugin response codes and messages
   private static final String OS = "OS";
   private static final String ANDROID = "Android";
   private static final String ERROR_CODE = "ErrorCode";
   private static final String ERROR_MESSAGE = "ErrorMessage";
-  private static final String NO_SECRET_KEY_CODE = "-5";
-  private static final String NO_SECRET_MESSAGE = "Secret Key not set.";
   private static final String NO_HARDWARE_CODE = "-6";
   private static final String NO_HARDWARE_MESSAGE = "Biometry is not available on this device.";
-  private static final String NO_FINGERPRINT_ENROLLED_CODE = "-7";
-  private static final String NO_FINGERPRINT_ENROLLED_MESSAGE =
-      "No fingers are enrolled with Touch ID.";
-
-  // Plugin Javascript actions
-  private static final String SAVE = "save";
-  private static final String VERIFY = "verify";
-  private static final String IS_AVAILABLE = "isAvailable";
-  private static final String SET_LOCALE = "setLocale";
-  private static final String HAS = "has";
-  private static final String DELETE = "delete";
 
   /**
    * Alias for our key in the Android Key Store
    */
-  private final static String CLIENT_ID = "CordovaTouchPlugin";
   public static String packageName;
-  public static KeyStore mKeyStore;
-  public static KeyGenerator mKeyGenerator;
-  public static Cipher mCipher;
   public static CallbackContext mCallbackContext;
   public static PluginResult mPluginResult;
-  /**
-   * Used to encrypt token
-   */
-  private static String mKeyID;
-  KeyguardManager mKeyguardManager;
-  FingerprintAuthenticationDialogFragment mFragment;
-  private FingerprintManager mFingerPrintManager;
-  private int mCurrentMode;
-  private String mLangCode = "en_US";
 
-  /**
-   * String to encrypt
-   */
-  private String mToEncrypt;
-
-  /**
-   * Require the user to authenticate with a fingerprint to authorize every use of the key
-   */
-  private boolean setUserAuthenticationRequired = false;
-
+  public FingerprintAuthAux mFingerprintAuthAux;
   /**
    * Constructor.
    */
   public FingerprintAuth() {
   }
 
-  /**
-   * Creates a symmetric key in the Android Key Store which can only be used after the user has
-   * authenticated with fingerprint.
-   */
-  public static boolean createKey(final boolean setUserAuthenticationRequired) {
-    String errorMessage = "";
-    String createKeyExceptionErrorPrefix = "Failed to create key: ";
-    boolean isKeyCreated = false;
-    // The enrolling flow for fingerprint. This is where you ask the user to set up fingerprint
-    // for your flow. Use of keys is necessary if you need to know if the set of
-    // enrolled fingerprints has changed.
-    try {
-      mKeyStore.load(null);
-      // Set the alias of the entry in Android KeyStore where the key will appear
-      // and the constrains (purposes) in the constructor of the Builder
-      mKeyGenerator.init(new KeyGenParameterSpec.Builder(CLIENT_ID,
-          KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT).setBlockModes(
-          KeyProperties.BLOCK_MODE_CBC)
-          .setUserAuthenticationRequired(setUserAuthenticationRequired)
-          .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_PKCS7)
-          .build());
-      mKeyGenerator.generateKey();
-      isKeyCreated = true;
-    } catch (NoSuchAlgorithmException e) {
-      errorMessage = createKeyExceptionErrorPrefix + "NoSuchAlgorithmException";
-    } catch (InvalidAlgorithmParameterException e) {
-      errorMessage = createKeyExceptionErrorPrefix + "InvalidAlgorithmParameterException";
-    } catch (CertificateException e) {
-      errorMessage = createKeyExceptionErrorPrefix + "CertificateException";
-    } catch (IOException e) {
-      errorMessage = createKeyExceptionErrorPrefix + "IOException";
-    }
-    if (!isKeyCreated) {
-      Log.e(TAG, errorMessage);
-      setPluginResultError(errorMessage);
-    }
-    return isKeyCreated;
-  }
-
   public static void onCancelled() {
     mCallbackContext.error("Cancelled");
   }
 
-  public static boolean setPluginResultError(String errorMessage) {
-    mCallbackContext.error(errorMessage);
-    mPluginResult = new PluginResult(PluginResult.Status.ERROR);
-    return false;
-  }
 
   /**
    * Sets the context of the Command. This can then be used to do things like
@@ -164,40 +52,21 @@ import org.json.JSONObject;
 
   public void initialize(CordovaInterface cordova, CordovaWebView webView) {
     super.initialize(cordova, webView);
-    Log.v(TAG, "Init FingerprintAuth");
+
     packageName = cordova.getActivity().getApplicationContext().getPackageName();
     mPluginResult = new PluginResult(PluginResult.Status.NO_RESULT);
+
+
 
     if (android.os.Build.VERSION.SDK_INT < 23) {
       return;
     }
-
-    mKeyguardManager = cordova.getActivity().getSystemService(KeyguardManager.class);
-    mFingerPrintManager =
-        cordova.getActivity().getApplicationContext().getSystemService(FingerprintManager.class);
-
-    try {
-      mKeyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEY_STORE);
-      mKeyStore = KeyStore.getInstance(ANDROID_KEY_STORE);
-    } catch (NoSuchAlgorithmException e) {
-      throw new RuntimeException("Failed to get an instance of KeyGenerator", e);
-    } catch (NoSuchProviderException e) {
-      throw new RuntimeException("Failed to get an instance of KeyGenerator", e);
-    } catch (KeyStoreException e) {
-      throw new RuntimeException("Failed to get an instance of KeyStore", e);
+    if (mFingerprintAuthAux == null) {
+      mFingerprintAuthAux = new FingerprintAuthAux(this);
     }
 
-    try {
-      mCipher = Cipher.getInstance(KeyProperties.KEY_ALGORITHM_AES
-          + "/"
-          + KeyProperties.BLOCK_MODE_CBC
-          + "/"
-          + KeyProperties.ENCRYPTION_PADDING_PKCS7);
-    } catch (NoSuchAlgorithmException e) {
-      throw new RuntimeException("Failed to get an instance of Cipher", e);
-    } catch (NoSuchPaddingException e) {
-      throw new RuntimeException("Failed to get an instance of Cipher", e);
-    }
+    mFingerprintAuthAux.initialize(cordova, webView);
+
   }
 
   /**
@@ -210,323 +79,23 @@ import org.json.JSONObject;
    */
   public boolean execute(final String action, JSONArray args, CallbackContext callbackContext)
       throws JSONException {
-    mCallbackContext = callbackContext;
-    Log.v(TAG, "FingerprintAuth action: " + action);
-    if (android.os.Build.VERSION.SDK_INT < 23) {
-      Log.e(TAG, "minimum SDK version 23 required");
 
+    if (android.os.Build.VERSION.SDK_INT < 23) {
       String errorMessage = createErrorMessage(NO_HARDWARE_CODE, NO_HARDWARE_MESSAGE);
       mPluginResult = new PluginResult(PluginResult.Status.ERROR, errorMessage);
       mCallbackContext.sendPluginResult(mPluginResult);
       return true;
     }
-    if (action.equals(SAVE)) {
-      final String key = args.getString(0);
-      final String password = args.getString(1);
-      setUserAuthenticationRequired = args.get(2).equals(null) || args.getBoolean(2);
 
-      if (isFingerprintAuthAvailable()) {
-        SecretKey secretKey = getSecretKey();
-
-        if (secretKey == null) {
-          if (createKey(setUserAuthenticationRequired)) {
-            getSecretKey();
-          }
-        }
-        mKeyID = key;
-        mToEncrypt = password;
-
-        if (setUserAuthenticationRequired) {
-          showFingerprintDialog(Cipher.ENCRYPT_MODE, null);
-        } else {
-          SharedPreferences sharedPref = cordova.getActivity().getPreferences(Context.MODE_PRIVATE);
-          SharedPreferences.Editor editor = sharedPref.edit();
-
-          if (initCipher(Cipher.ENCRYPT_MODE)) {
-            byte[] enc = new byte[0];
-            try {
-              enc = mCipher.doFinal(mToEncrypt.getBytes());
-
-              editor.putString("fing" + mKeyID, Base64.encodeToString(enc, Base64.DEFAULT));
-              editor.putString("fing_iv" + mKeyID,
-                  Base64.encodeToString(mCipher.getIV(), Base64.DEFAULT));
-
-              editor.apply();
-              mPluginResult = new PluginResult(PluginResult.Status.OK);
-              mCallbackContext.sendPluginResult(mPluginResult);
-              return true;
-            } catch (IllegalBlockSizeException e) {
-              mPluginResult =
-                  new PluginResult(PluginResult.Status.ERROR, "Error string is to big.");
-            } catch (BadPaddingException e) {
-              mPluginResult = new PluginResult(PluginResult.Status.ERROR, "Error Bad Padding.");
-            }
-            mCallbackContext.sendPluginResult(mPluginResult);
-          }
-        }
-      } else {
-        String errorMessage = createErrorMessage(NO_HARDWARE_CODE, NO_HARDWARE_MESSAGE);
-        mPluginResult = new PluginResult(PluginResult.Status.ERROR, errorMessage);
-      }
-      return true;
-    } else if (action.equals(VERIFY)) {
-      final String key = args.getString(0);
-      final String message = args.getString(1);
-      if (isHardwareDetected()) {
-        if (hasEnrolledFingerprints()) {
-          SecretKey secretKey = getSecretKey();
-          if (secretKey != null) {
-            mKeyID = key;
-            showFingerprintDialog(Cipher.DECRYPT_MODE, message);
-            mPluginResult.setKeepCallback(true);
-          } else {
-            String errorMessage = createErrorMessage(NO_SECRET_KEY_CODE, NO_SECRET_MESSAGE);
-            mPluginResult = new PluginResult(PluginResult.Status.ERROR, errorMessage);
-            mCallbackContext.sendPluginResult(mPluginResult);
-          }
-        } else {
-          String errorMessage =
-              createErrorMessage(NO_FINGERPRINT_ENROLLED_CODE, NO_FINGERPRINT_ENROLLED_MESSAGE);
-          mPluginResult = new PluginResult(PluginResult.Status.ERROR, errorMessage);
-          mCallbackContext.sendPluginResult(mPluginResult);
-        }
-      } else {
-        String errorMessage = createErrorMessage(NO_HARDWARE_CODE, NO_HARDWARE_MESSAGE);
-        mPluginResult = new PluginResult(PluginResult.Status.ERROR, errorMessage);
-        mCallbackContext.sendPluginResult(mPluginResult);
-      }
-      return true;
-    } else if (action.equals(IS_AVAILABLE)) {
-      if (isHardwareDetected()) {
-        if (hasEnrolledFingerprints()) {
-          mPluginResult = new PluginResult(PluginResult.Status.OK);
-        } else {
-          String errorMessage =
-              createErrorMessage(NO_FINGERPRINT_ENROLLED_CODE, NO_FINGERPRINT_ENROLLED_MESSAGE);
-          mPluginResult = new PluginResult(PluginResult.Status.ERROR, errorMessage);
-        }
-      } else {
-        String errorMessage = createErrorMessage(NO_HARDWARE_CODE, NO_HARDWARE_MESSAGE);
-        mPluginResult = new PluginResult(PluginResult.Status.ERROR, errorMessage);
-      }
-
-      mCallbackContext.sendPluginResult(mPluginResult);
-      return true;
-    } else if (action.equals(SET_LOCALE)) {            // Set language
-      mLangCode = args.getString(0);
-      Resources res = cordova.getActivity().getResources();
-
-      // Change locale settings in the app.
-      DisplayMetrics dm = res.getDisplayMetrics();
-
-      Configuration conf = res.getConfiguration();
-      conf.locale = new Locale(mLangCode.toLowerCase());
-
-      res.updateConfiguration(conf, dm);
-      return true;
-    } else if (action.equals(HAS)) { //if has key
-      String key = args.getString(0);
-
-      SharedPreferences sharedPref = cordova.getActivity().getPreferences(Context.MODE_PRIVATE);
-      String enc = sharedPref.getString("fing" + key, "");
-
-      if (!enc.equals("")) {
-        mPluginResult = new PluginResult(PluginResult.Status.OK);
-      } else {
-        mPluginResult = new PluginResult(PluginResult.Status.ERROR);
-      }
-
-      mCallbackContext.sendPluginResult(mPluginResult);
-      return true;
-    } else if (action.equals(DELETE)) { //delete key
-      final String key = args.getString(0);
-      SharedPreferences sharedPref = cordova.getActivity().getPreferences(Context.MODE_PRIVATE);
-      SharedPreferences.Editor editor = sharedPref.edit();
-      editor.remove("fing" + key);
-      editor.remove("fing_iv" + key);
-      boolean removed = editor.commit();
-      if (removed) {
-        mPluginResult = new PluginResult(PluginResult.Status.OK);
-      } else {
-        mPluginResult = new PluginResult(PluginResult.Status.ERROR);
-      }
-      mCallbackContext.sendPluginResult(mPluginResult);
-      return true;
-    }
-    return false;
-  }
-
-  private boolean isFingerprintAuthAvailable() {
-    return isHardwareDetected() && hasEnrolledFingerprints();
-  }
-
-  private boolean isHardwareDetected() {
-    return mFingerPrintManager.isHardwareDetected();
-  }
-
-  private boolean hasEnrolledFingerprints() {
-    return mFingerPrintManager.hasEnrolledFingerprints();
-  }
-
-  /**
-   * Initialize the {@link Cipher} instance with the created key in the
-   * {@link #createKey(boolean setUserAuthenticationRequired)}
-   * method.
-   *
-   * @return {@code true} if initialization is successful, {@code false} if the lock screen has
-   * been disabled or reset after the key was generated, or if a fingerprint got enrolled after
-   * the key was generated.
-   */
-  private boolean initCipher(int mode) {
-    boolean initCipher = false;
-    String errorMessage = "";
-    String initCipherExceptionErrorPrefix = "Failed to init Cipher: ";
-    try {
-      SecretKey key = getSecretKey();
-
-      if (mode == Cipher.ENCRYPT_MODE) {
-        SecureRandom r = new SecureRandom();
-        byte[] ivBytes = new byte[16];
-        r.nextBytes(ivBytes);
-
-        mCipher.init(mode, key);
-      } else {
-        SharedPreferences sharedPref = cordova.getActivity().getPreferences(Context.MODE_PRIVATE);
-        byte[] ivBytes =
-            Base64.decode(sharedPref.getString("fing_iv" + mKeyID, ""), Base64.DEFAULT);
-
-        mCipher.init(mode, key, new IvParameterSpec(ivBytes));
-      }
-
-      initCipher = true;
-    } catch (KeyPermanentlyInvalidatedException e) {
-      removePermanentlyInvalidatedKey();
-      errorMessage = "KeyPermanentlyInvalidatedException";
-      setPluginResultError(errorMessage);
-    } catch (InvalidKeyException e) {
-      errorMessage = initCipherExceptionErrorPrefix + "InvalidKeyException";
-    } catch (InvalidAlgorithmParameterException e) {
-      errorMessage = initCipherExceptionErrorPrefix + "InvalidAlgorithmParameterException";
-      e.printStackTrace();
-    }
-    if (!initCipher) {
-      Log.e(TAG, errorMessage);
-    }
-    return initCipher;
-  }
-
-  private SecretKey getSecretKey() {
-    String errorMessage = "";
-    String getSecretKeyExceptionErrorPrefix = "Failed to get SecretKey from KeyStore: ";
-    SecretKey key = null;
-    try {
-      mKeyStore.load(null);
-      key = (SecretKey) mKeyStore.getKey(CLIENT_ID, null);
-    } catch (KeyStoreException e) {
-      errorMessage = getSecretKeyExceptionErrorPrefix + "KeyStoreException";
-    } catch (CertificateException e) {
-      errorMessage = getSecretKeyExceptionErrorPrefix + "CertificateException";
-    } catch (UnrecoverableKeyException e) {
-      errorMessage = getSecretKeyExceptionErrorPrefix + "UnrecoverableKeyException";
-    } catch (IOException e) {
-      errorMessage = getSecretKeyExceptionErrorPrefix + "IOException";
-    } catch (NoSuchAlgorithmException e) {
-      errorMessage = getSecretKeyExceptionErrorPrefix + "NoSuchAlgorithmException";
-    } catch (UnrecoverableEntryException e) {
-      errorMessage = getSecretKeyExceptionErrorPrefix + "UnrecoverableEntryException";
-    }
-    if (key == null) {
-      Log.e(TAG, errorMessage);
-    }
-    return key;
-  }
-
-  public void showFingerprintDialog(final int mode, final String message) {
-    final FingerprintAuth auth = this;
-    mCurrentMode = mode;
-    cordova.getActivity().runOnUiThread(new Runnable() {
-      public void run() {
-        // Set up the crypto object for later. The object will be authenticated by use
-        // of the fingerprint.
-        mFragment = new FingerprintAuthenticationDialogFragment();
-        Bundle bundle = new Bundle();
-        bundle.putInt("dialogMode", mode);
-        bundle.putString("dialogMessage", message);
-        mFragment.setArguments(bundle);
-        mFragment.setmFingerPrintAuth(auth);
-
-        if (initCipher(mode)) {
-          mFragment.setCancelable(false);
-          // Show the fingerprint dialog. The user has the option to use the fingerprint with
-          // crypto, or you can fall back to using a server-side verified password.
-          mFragment.setCryptoObject(new FingerprintManager.CryptoObject(mCipher));
-          mFragment.show(cordova.getActivity().getFragmentManager(), DIALOG_FRAGMENT_TAG);
-        } else {
-          mPluginResult = new PluginResult(PluginResult.Status.ERROR, "Failed to init Cipher");
-          mCallbackContext.sendPluginResult(mPluginResult);
-        }
-      }
-    });
-  }
-
-  public void onAuthenticated(boolean withFingerprint) {
-    String result = "";
-    String errorMessage = "";
-    try {
-
-      if (withFingerprint) {
-        // If the user has authenticated with fingerprint, verify that using cryptography and
-        // then return the encrypted token
-        SharedPreferences sharedPref = cordova.getActivity().getPreferences(Context.MODE_PRIVATE);
-        if (mCurrentMode == Cipher.DECRYPT_MODE) {
-          byte[] enc = Base64.decode(sharedPref.getString("fing" + mKeyID, ""), Base64.DEFAULT);
-
-          byte[] decrypted = mCipher.doFinal(enc);
-          result = new String(decrypted);
-        } else if (mCurrentMode == Cipher.ENCRYPT_MODE && setUserAuthenticationRequired) {
-          //If setUserAuthenticationRequired encript string with key after authenticate with fingerprint
-          SharedPreferences.Editor editor = sharedPref.edit();
-
-          byte[] enc = mCipher.doFinal(mToEncrypt.getBytes());
-          editor.putString("fing" + mKeyID, Base64.encodeToString(enc, Base64.DEFAULT));
-          editor.putString("fing_iv" + mKeyID,
-              Base64.encodeToString(mCipher.getIV(), Base64.DEFAULT));
-
-          editor.apply();
-          mToEncrypt = "";
-          result = "success";
-        }
-      }
-    } catch (BadPaddingException e) {
-      errorMessage = "Failed to encrypt the data with the generated key:"
-          + " BadPaddingException:  "
-          + e.getMessage();
-      Log.e(TAG, errorMessage);
-    } catch (IllegalBlockSizeException e) {
-      errorMessage = "Failed to encrypt the data with the generated key: "
-          + "IllegalBlockSizeException: "
-          + e.getMessage();
-      Log.e(TAG, errorMessage);
+    if (mFingerprintAuthAux == null) {
+      mFingerprintAuthAux = new FingerprintAuthAux(this);
     }
 
-    if (!result.equals("")) {
-      mPluginResult = new PluginResult(PluginResult.Status.OK, result);
-      mPluginResult.setKeepCallback(false);
-    } else {
-      mPluginResult = new PluginResult(PluginResult.Status.ERROR, errorMessage);
-      mPluginResult.setKeepCallback(false);
-    }
-    mCallbackContext.sendPluginResult(mPluginResult);
+
+    return mFingerprintAuthAux.execute(action, args, callbackContext, cordova);
+
   }
 
-  private void removePermanentlyInvalidatedKey() {
-    try {
-      mKeyStore.deleteEntry(CLIENT_ID);
-      Log.i(TAG, "Permanently invalidated key was removed.");
-    } catch (KeyStoreException e) {
-      Log.e(TAG, e.getMessage());
-    }
-  }
 
   private String createErrorMessage(final String errorCode, final String errorMessage) {
     JSONObject resultJson = new JSONObject();
@@ -539,5 +108,6 @@ import org.json.JSONObject;
       Log.e(TAG, e.getMessage());
     }
     return "";
+
   }
 }

--- a/src/android/FingerprintAuthAux.java
+++ b/src/android/FingerprintAuthAux.java
@@ -77,6 +77,7 @@ public class FingerprintAuthAux {
     private static final String SET_LOCALE = "setLocale";
     private static final String HAS = "has";
     private static final String DELETE = "delete";
+    private static final String MOVE = "move";
 
     /**
      * Alias for our key in the Android Key Store

--- a/src/android/FingerprintAuthAux.java
+++ b/src/android/FingerprintAuthAux.java
@@ -1,0 +1,563 @@
+package com.cordova.plugin.android.fingerprintauth;
+
+/**
+ * Created by manuelmouta on 24/02/2017.
+ */
+
+import android.Manifest;
+import android.app.KeyguardManager;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
+import android.content.res.Configuration;
+import android.content.res.Resources;
+import android.hardware.fingerprint.FingerprintManager;
+import android.os.Bundle;
+import android.security.keystore.KeyGenParameterSpec;
+import android.security.keystore.KeyPermanentlyInvalidatedException;
+import android.security.keystore.KeyProperties;
+import android.util.Base64;
+import android.util.DisplayMetrics;
+import android.util.Log;
+
+import org.apache.cordova.CallbackContext;
+import org.apache.cordova.CordovaInterface;
+import org.apache.cordova.CordovaWebView;
+import org.apache.cordova.PluginResult;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.SecureRandom;
+import java.security.UnrecoverableEntryException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
+import java.util.Locale;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.KeyGenerator;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.IvParameterSpec;
+
+
+public class FingerprintAuthAux {
+
+    public static final String TAG = "FingerprintAuth";
+    private static final String DIALOG_FRAGMENT_TAG = "FpAuthDialog";
+    private static final String ANDROID_KEY_STORE = "AndroidKeyStore";
+
+    // Plugin response codes and messages
+    private static final String OS = "OS";
+    private static final String ANDROID = "Android";
+    private static final String ERROR_CODE = "ErrorCode";
+    private static final String ERROR_MESSAGE = "ErrorMessage";
+    private static final String NO_SECRET_KEY_CODE = "-5";
+    private static final String NO_SECRET_MESSAGE = "Secret Key not set.";
+    private static final String NO_HARDWARE_CODE = "-6";
+    private static final String NO_HARDWARE_MESSAGE = "Biometry is not available on this device.";
+    private static final String NO_FINGERPRINT_ENROLLED_CODE = "-7";
+    private static final String NO_FINGERPRINT_ENROLLED_MESSAGE =
+            "No fingers are enrolled with Touch ID.";
+
+    // Plugin Javascript actions
+    private static final String SAVE = "save";
+    private static final String VERIFY = "verify";
+    private static final String IS_AVAILABLE = "isAvailable";
+    private static final String SET_LOCALE = "setLocale";
+    private static final String HAS = "has";
+    private static final String DELETE = "delete";
+
+    /**
+     * Alias for our key in the Android Key Store
+     */
+    private final static String CLIENT_ID = "CordovaTouchPlugin";
+    public static String packageName;
+    public static KeyStore mKeyStore;
+    public static KeyGenerator mKeyGenerator;
+    public static Cipher mCipher;
+    public static CallbackContext mCallbackContext;
+    public static PluginResult mPluginResult;
+    /**
+     * Used to encrypt token
+     */
+    private static String mKeyID;
+    KeyguardManager mKeyguardManager;
+    FingerprintAuthenticationDialogFragment mFragment;
+    private FingerprintManager mFingerPrintManager;
+    private int mCurrentMode;
+    private String mLangCode = "en_US";
+
+    private FingerprintAuth mParentCordovaPlugin;
+    /**
+     * String to encrypt
+     */
+    private String mToEncrypt;
+
+    /**
+     * Require the user to authenticate with a fingerprint to authorize every use of the key
+     */
+    private boolean setUserAuthenticationRequired = false;
+
+    /**
+     * Constructor.
+     */
+    public FingerprintAuthAux(FingerprintAuth mainCordovaPlugin) {
+        mParentCordovaPlugin = mainCordovaPlugin;
+    }
+
+    /**
+     * Creates a symmetric key in the Android Key Store which can only be used after the user has
+     * authenticated with fingerprint.
+     */
+    public static boolean createKey(final boolean setUserAuthenticationRequired) {
+        String errorMessage = "";
+        String createKeyExceptionErrorPrefix = "Failed to create key: ";
+        boolean isKeyCreated = false;
+        // The enrolling flow for fingerprint. This is where you ask the user to set up fingerprint
+        // for your flow. Use of keys is necessary if you need to know if the set of
+        // enrolled fingerprints has changed.
+        try {
+            mKeyStore.load(null);
+            // Set the alias of the entry in Android KeyStore where the key will appear
+            // and the constrains (purposes) in the constructor of the Builder
+            mKeyGenerator.init(new KeyGenParameterSpec.Builder(CLIENT_ID,
+                    KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT).setBlockModes(
+                    KeyProperties.BLOCK_MODE_CBC)
+                    .setUserAuthenticationRequired(setUserAuthenticationRequired)
+                    .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_PKCS7)
+                    .build());
+            mKeyGenerator.generateKey();
+            isKeyCreated = true;
+        } catch (NoSuchAlgorithmException e) {
+            errorMessage = createKeyExceptionErrorPrefix + "NoSuchAlgorithmException";
+        } catch (InvalidAlgorithmParameterException e) {
+            errorMessage = createKeyExceptionErrorPrefix + "InvalidAlgorithmParameterException";
+        } catch (CertificateException e) {
+            errorMessage = createKeyExceptionErrorPrefix + "CertificateException";
+        } catch (IOException e) {
+            errorMessage = createKeyExceptionErrorPrefix + "IOException";
+        }
+        if (!isKeyCreated) {
+            Log.e(TAG, errorMessage);
+            setPluginResultError(errorMessage);
+        }
+        return isKeyCreated;
+    }
+
+    public static void onCancelled() {
+        mCallbackContext.error("Cancelled");
+    }
+
+    public static boolean setPluginResultError(String errorMessage) {
+        mCallbackContext.error(errorMessage);
+        mPluginResult = new PluginResult(PluginResult.Status.ERROR);
+        return false;
+    }
+
+    /**
+     * Sets the context of the Command. This can then be used to do things like
+     * get file paths associated with the Activity.
+     *
+     * @param cordova The context of the main Activity.
+     * @param webView The CordovaWebView Cordova is running in.
+     */
+
+    public void initialize(CordovaInterface cordova, CordovaWebView webView) {
+
+        Log.v(TAG, "Init FingerprintAuth");
+        packageName = cordova.getActivity().getApplicationContext().getPackageName();
+        mPluginResult = new PluginResult(PluginResult.Status.NO_RESULT);
+
+        if (android.os.Build.VERSION.SDK_INT < 23) {
+            return;
+        }
+
+        mKeyguardManager = cordova.getActivity().getSystemService(KeyguardManager.class);
+        mFingerPrintManager =
+                cordova.getActivity().getApplicationContext().getSystemService(FingerprintManager.class);
+
+        try {
+            mKeyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEY_STORE);
+            mKeyStore = KeyStore.getInstance(ANDROID_KEY_STORE);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("Failed to get an instance of KeyGenerator", e);
+        } catch (NoSuchProviderException e) {
+            throw new RuntimeException("Failed to get an instance of KeyGenerator", e);
+        } catch (KeyStoreException e) {
+            throw new RuntimeException("Failed to get an instance of KeyStore", e);
+        }
+
+        try {
+            mCipher = Cipher.getInstance(KeyProperties.KEY_ALGORITHM_AES
+                    + "/"
+                    + KeyProperties.BLOCK_MODE_CBC
+                    + "/"
+                    + KeyProperties.ENCRYPTION_PADDING_PKCS7);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("Failed to get an instance of Cipher", e);
+        } catch (NoSuchPaddingException e) {
+            throw new RuntimeException("Failed to get an instance of Cipher", e);
+        }
+    }
+
+    /**
+     * Executes the request and returns PluginResult.
+     *
+     * @param action The action to execute.
+     * @param args JSONArry of arguments for the plugin.
+     * @param callbackContext The callback id used when calling back into JavaScript.
+     * @return A PluginResult object with a status and message.
+     */
+    public boolean execute(final String action, JSONArray args, CallbackContext callbackContext, CordovaInterface cordova)
+            throws JSONException {
+        mCallbackContext = callbackContext;
+        Log.v(TAG, "FingerprintAuth action: " + action);
+        if (android.os.Build.VERSION.SDK_INT < 23) {
+            Log.e(TAG, "minimum SDK version 23 required");
+
+            String errorMessage = createErrorMessage(NO_HARDWARE_CODE, NO_HARDWARE_MESSAGE);
+            mPluginResult = new PluginResult(PluginResult.Status.ERROR, errorMessage);
+            mCallbackContext.sendPluginResult(mPluginResult);
+            return true;
+        }
+        if (action.equals(SAVE)) {
+            final String key = args.getString(0);
+            final String password = args.getString(1);
+            setUserAuthenticationRequired = args.get(2).equals(null) || args.getBoolean(2);
+
+            if (isFingerprintAuthAvailable()) {
+                SecretKey secretKey = getSecretKey();
+
+                if (secretKey == null) {
+                    if (createKey(setUserAuthenticationRequired)) {
+                        getSecretKey();
+                    }
+                }
+                mKeyID = key;
+                mToEncrypt = password;
+
+                if (setUserAuthenticationRequired) {
+                    showFingerprintDialog(Cipher.ENCRYPT_MODE, null, cordova);
+                } else {
+                    SharedPreferences sharedPref = cordova.getActivity().getPreferences(Context.MODE_PRIVATE);
+                    SharedPreferences.Editor editor = sharedPref.edit();
+
+                    if (initCipher(Cipher.ENCRYPT_MODE, cordova)) {
+                        byte[] enc = new byte[0];
+                        try {
+                            enc = mCipher.doFinal(mToEncrypt.getBytes());
+
+                            editor.putString("fing" + mKeyID, Base64.encodeToString(enc, Base64.DEFAULT));
+                            editor.putString("fing_iv" + mKeyID,
+                                    Base64.encodeToString(mCipher.getIV(), Base64.DEFAULT));
+
+                            editor.apply();
+                            mPluginResult = new PluginResult(PluginResult.Status.OK);
+                            mCallbackContext.sendPluginResult(mPluginResult);
+                            return true;
+                        } catch (IllegalBlockSizeException e) {
+                            mPluginResult =
+                                    new PluginResult(PluginResult.Status.ERROR, "Error string is to big.");
+                        } catch (BadPaddingException e) {
+                            mPluginResult = new PluginResult(PluginResult.Status.ERROR, "Error Bad Padding.");
+                        }
+                        mCallbackContext.sendPluginResult(mPluginResult);
+                    }
+                }
+            } else {
+                String errorMessage = createErrorMessage(NO_HARDWARE_CODE, NO_HARDWARE_MESSAGE);
+                mPluginResult = new PluginResult(PluginResult.Status.ERROR, errorMessage);
+            }
+            return true;
+        } else if (action.equals(VERIFY)) {
+            final String key = args.getString(0);
+            final String message = args.getString(1);
+            if (isHardwareDetected()) {
+                if (hasEnrolledFingerprints()) {
+                    SecretKey secretKey = getSecretKey();
+                    if (secretKey != null) {
+                        mKeyID = key;
+                        showFingerprintDialog(Cipher.DECRYPT_MODE, message, cordova);
+                        mPluginResult.setKeepCallback(true);
+                    } else {
+                        String errorMessage = createErrorMessage(NO_SECRET_KEY_CODE, NO_SECRET_MESSAGE);
+                        mPluginResult = new PluginResult(PluginResult.Status.ERROR, errorMessage);
+                        mCallbackContext.sendPluginResult(mPluginResult);
+                    }
+                } else {
+                    String errorMessage =
+                            createErrorMessage(NO_FINGERPRINT_ENROLLED_CODE, NO_FINGERPRINT_ENROLLED_MESSAGE);
+                    mPluginResult = new PluginResult(PluginResult.Status.ERROR, errorMessage);
+                    mCallbackContext.sendPluginResult(mPluginResult);
+                }
+            } else {
+                String errorMessage = createErrorMessage(NO_HARDWARE_CODE, NO_HARDWARE_MESSAGE);
+                mPluginResult = new PluginResult(PluginResult.Status.ERROR, errorMessage);
+                mCallbackContext.sendPluginResult(mPluginResult);
+            }
+            return true;
+        } else if (action.equals(IS_AVAILABLE)) {
+            if (isHardwareDetected()) {
+                if (hasEnrolledFingerprints()) {
+                    mPluginResult = new PluginResult(PluginResult.Status.OK);
+                } else {
+                    String errorMessage =
+                            createErrorMessage(NO_FINGERPRINT_ENROLLED_CODE, NO_FINGERPRINT_ENROLLED_MESSAGE);
+                    mPluginResult = new PluginResult(PluginResult.Status.ERROR, errorMessage);
+                }
+            } else {
+                String errorMessage = createErrorMessage(NO_HARDWARE_CODE, NO_HARDWARE_MESSAGE);
+                mPluginResult = new PluginResult(PluginResult.Status.ERROR, errorMessage);
+            }
+
+            mCallbackContext.sendPluginResult(mPluginResult);
+            return true;
+        } else if (action.equals(SET_LOCALE)) {            // Set language
+            mLangCode = args.getString(0);
+            Resources res = cordova.getActivity().getResources();
+
+            // Change locale settings in the app.
+            DisplayMetrics dm = res.getDisplayMetrics();
+
+            Configuration conf = res.getConfiguration();
+            conf.locale = new Locale(mLangCode.toLowerCase());
+
+            res.updateConfiguration(conf, dm);
+            return true;
+        } else if (action.equals(HAS)) { //if has key
+            String key = args.getString(0);
+
+            SharedPreferences sharedPref = cordova.getActivity().getPreferences(Context.MODE_PRIVATE);
+            String enc = sharedPref.getString("fing" + key, "");
+
+            if (!enc.equals("")) {
+                mPluginResult = new PluginResult(PluginResult.Status.OK);
+            } else {
+                mPluginResult = new PluginResult(PluginResult.Status.ERROR);
+            }
+
+            mCallbackContext.sendPluginResult(mPluginResult);
+            return true;
+        } else if (action.equals(DELETE)) { //delete key
+            final String key = args.getString(0);
+            SharedPreferences sharedPref = cordova.getActivity().getPreferences(Context.MODE_PRIVATE);
+            SharedPreferences.Editor editor = sharedPref.edit();
+            editor.remove("fing" + key);
+            editor.remove("fing_iv" + key);
+            boolean removed = editor.commit();
+            if (removed) {
+                mPluginResult = new PluginResult(PluginResult.Status.OK);
+            } else {
+                mPluginResult = new PluginResult(PluginResult.Status.ERROR);
+            }
+            mCallbackContext.sendPluginResult(mPluginResult);
+            return true;
+        }
+        return false;
+    }
+
+    private boolean isFingerprintAuthAvailable() {
+        return isHardwareDetected() && hasEnrolledFingerprints();
+    }
+
+    private boolean isHardwareDetected() {
+        if (mParentCordovaPlugin == null || mParentCordovaPlugin.cordova.getActivity().checkSelfPermission(Manifest.permission.USE_FINGERPRINT) != PackageManager.PERMISSION_GRANTED) {
+            return false;
+        }
+
+        return mFingerPrintManager.isHardwareDetected();
+    }
+
+    private boolean hasEnrolledFingerprints() {
+        if (mParentCordovaPlugin == null || mParentCordovaPlugin.cordova.getActivity().checkSelfPermission(Manifest.permission.USE_FINGERPRINT) != PackageManager.PERMISSION_GRANTED) {
+            return false;
+        }
+
+        return mFingerPrintManager.hasEnrolledFingerprints();
+    }
+
+    /**
+     * Initialize the {@link Cipher} instance with the created key in the
+     * {@link #createKey(boolean setUserAuthenticationRequired)}
+     * method.
+     *
+     * @return {@code true} if initialization is successful, {@code false} if the lock screen has
+     * been disabled or reset after the key was generated, or if a fingerprint got enrolled after
+     * the key was generated.
+     */
+    private boolean initCipher(int mode, CordovaInterface cordova) {
+        boolean initCipher = false;
+        String errorMessage = "";
+        String initCipherExceptionErrorPrefix = "Failed to init Cipher: ";
+        try {
+            SecretKey key = getSecretKey();
+
+            if (mode == Cipher.ENCRYPT_MODE) {
+                SecureRandom r = new SecureRandom();
+                byte[] ivBytes = new byte[16];
+                r.nextBytes(ivBytes);
+
+                mCipher.init(mode, key);
+            } else {
+                SharedPreferences sharedPref = cordova.getActivity().getPreferences(Context.MODE_PRIVATE);
+                byte[] ivBytes =
+                        Base64.decode(sharedPref.getString("fing_iv" + mKeyID, ""), Base64.DEFAULT);
+
+                mCipher.init(mode, key, new IvParameterSpec(ivBytes));
+            }
+
+            initCipher = true;
+        } catch (KeyPermanentlyInvalidatedException e) {
+            removePermanentlyInvalidatedKey();
+            errorMessage = "KeyPermanentlyInvalidatedException";
+            setPluginResultError(errorMessage);
+        } catch (InvalidKeyException e) {
+            errorMessage = initCipherExceptionErrorPrefix + "InvalidKeyException";
+        } catch (InvalidAlgorithmParameterException e) {
+            errorMessage = initCipherExceptionErrorPrefix + "InvalidAlgorithmParameterException";
+            e.printStackTrace();
+        }
+        if (!initCipher) {
+            Log.e(TAG, errorMessage);
+        }
+        return initCipher;
+    }
+
+    private SecretKey getSecretKey() {
+        String errorMessage = "";
+        String getSecretKeyExceptionErrorPrefix = "Failed to get SecretKey from KeyStore: ";
+        SecretKey key = null;
+        try {
+            mKeyStore.load(null);
+            key = (SecretKey) mKeyStore.getKey(CLIENT_ID, null);
+        } catch (KeyStoreException e) {
+            errorMessage = getSecretKeyExceptionErrorPrefix + "KeyStoreException";
+        } catch (CertificateException e) {
+            errorMessage = getSecretKeyExceptionErrorPrefix + "CertificateException";
+        } catch (UnrecoverableKeyException e) {
+            errorMessage = getSecretKeyExceptionErrorPrefix + "UnrecoverableKeyException";
+        } catch (IOException e) {
+            errorMessage = getSecretKeyExceptionErrorPrefix + "IOException";
+        } catch (NoSuchAlgorithmException e) {
+            errorMessage = getSecretKeyExceptionErrorPrefix + "NoSuchAlgorithmException";
+        } catch (UnrecoverableEntryException e) {
+            errorMessage = getSecretKeyExceptionErrorPrefix + "UnrecoverableEntryException";
+        }
+        if (key == null) {
+            Log.e(TAG, errorMessage);
+        }
+        return key;
+    }
+
+    public void showFingerprintDialog(final int mode, final String message, final CordovaInterface cordova) {
+        final FingerprintAuthAux auth = this;
+        mCurrentMode = mode;
+        cordova.getActivity().runOnUiThread(new Runnable() {
+            public void run() {
+                // Set up the crypto object for later. The object will be authenticated by use
+                // of the fingerprint.
+                mFragment = new FingerprintAuthenticationDialogFragment();
+                Bundle bundle = new Bundle();
+                bundle.putInt("dialogMode", mode);
+                bundle.putString("dialogMessage", message);
+                mFragment.setArguments(bundle);
+                mFragment.setmFingerPrintAuth(auth);
+
+                if (initCipher(mode, cordova)) {
+                    mFragment.setCancelable(false);
+                    // Show the fingerprint dialog. The user has the option to use the fingerprint with
+                    // crypto, or you can fall back to using a server-side verified password.
+                    mFragment.setCryptoObject(new FingerprintManager.CryptoObject(mCipher));
+                    mFragment.show(cordova.getActivity().getFragmentManager(), DIALOG_FRAGMENT_TAG);
+                } else {
+                    mPluginResult = new PluginResult(PluginResult.Status.ERROR, "Failed to init Cipher");
+                    mCallbackContext.sendPluginResult(mPluginResult);
+                }
+            }
+        });
+    }
+
+    public void onAuthenticated(boolean withFingerprint) {
+        String result = "";
+        String errorMessage = "";
+        try {
+
+            CordovaInterface cordova = mParentCordovaPlugin.cordova;
+            if (withFingerprint) {
+                // If the user has authenticated with fingerprint, verify that using cryptography and
+                // then return the encrypted token
+                SharedPreferences sharedPref = cordova.getActivity().getPreferences(Context.MODE_PRIVATE);
+                if (mCurrentMode == Cipher.DECRYPT_MODE) {
+                    byte[] enc = Base64.decode(sharedPref.getString("fing" + mKeyID, ""), Base64.DEFAULT);
+
+                    byte[] decrypted = mCipher.doFinal(enc);
+                    result = new String(decrypted);
+                } else if (mCurrentMode == Cipher.ENCRYPT_MODE && setUserAuthenticationRequired) {
+                    //If setUserAuthenticationRequired encript string with key after authenticate with fingerprint
+                    SharedPreferences.Editor editor = sharedPref.edit();
+
+                    byte[] enc = mCipher.doFinal(mToEncrypt.getBytes());
+                    editor.putString("fing" + mKeyID, Base64.encodeToString(enc, Base64.DEFAULT));
+                    editor.putString("fing_iv" + mKeyID,
+                            Base64.encodeToString(mCipher.getIV(), Base64.DEFAULT));
+
+                    editor.apply();
+                    mToEncrypt = "";
+                    result = "success";
+                }
+            }
+        } catch (BadPaddingException e) {
+            errorMessage = "Failed to encrypt the data with the generated key:"
+                    + " BadPaddingException:  "
+                    + e.getMessage();
+            Log.e(TAG, errorMessage);
+        } catch (IllegalBlockSizeException e) {
+            errorMessage = "Failed to encrypt the data with the generated key: "
+                    + "IllegalBlockSizeException: "
+                    + e.getMessage();
+            Log.e(TAG, errorMessage);
+        }
+
+        if (!result.equals("")) {
+            mPluginResult = new PluginResult(PluginResult.Status.OK, result);
+            mPluginResult.setKeepCallback(false);
+        } else {
+            mPluginResult = new PluginResult(PluginResult.Status.ERROR, errorMessage);
+            mPluginResult.setKeepCallback(false);
+        }
+        mCallbackContext.sendPluginResult(mPluginResult);
+    }
+
+    private void removePermanentlyInvalidatedKey() {
+        try {
+            mKeyStore.deleteEntry(CLIENT_ID);
+            Log.i(TAG, "Permanently invalidated key was removed.");
+        } catch (KeyStoreException e) {
+            Log.e(TAG, e.getMessage());
+        }
+    }
+
+    private String createErrorMessage(final String errorCode, final String errorMessage) {
+        JSONObject resultJson = new JSONObject();
+        try {
+            resultJson.put(OS, ANDROID);
+            resultJson.put(ERROR_CODE, errorCode);
+            resultJson.put(ERROR_MESSAGE, errorMessage);
+            return resultJson.toString();
+        } catch (JSONException e) {
+            Log.e(TAG, e.getMessage());
+        }
+        return "";
+    }
+
+}

--- a/src/android/FingerprintAuthAux.java
+++ b/src/android/FingerprintAuthAux.java
@@ -376,7 +376,7 @@ public class FingerprintAuthAux {
                 SharedPreferences.Editor newEditor = newSharedPref.edit();
                 newEditor.putString("fing" + key, oldSharedPref.getString("fing" + key, ""));
                 newEditor.putString("fing_iv" + key, oldSharedPref.getString("fing" + key, ""));
-                newEditor.apply();
+                newEditor.commit();
                 
                 SharedPreferences.Editor oldEditor = oldSharedPref.edit();
                 oldEditor.remove("fing" + key);
@@ -536,7 +536,7 @@ public class FingerprintAuthAux {
                     editor.putString("fing_iv" + mKeyID,
                             Base64.encodeToString(mCipher.getIV(), Base64.DEFAULT));
 
-                    editor.apply();
+                    editor.commit();
                     mToEncrypt = "";
                     result = "success";
                 }

--- a/src/android/FingerprintAuthAux.java
+++ b/src/android/FingerprintAuthAux.java
@@ -375,7 +375,7 @@ public class FingerprintAuthAux {
                 SharedPreferences newSharedPref = cordova.getActivity().getApplicationContext().getSharedPreferences(SHARED_PREFS_NAME,Context.MODE_PRIVATE);
                 SharedPreferences.Editor newEditor = newSharedPref.edit();
                 newEditor.putString("fing" + key, oldSharedPref.getString("fing" + key, ""));
-                newEditor.putString("fing_iv" + key, oldSharedPref.getString("fing" + key, ""));
+                newEditor.putString("fing_iv" + key, oldSharedPref.getString("fing_iv" + key, ""));
                 newEditor.commit();
                 
                 SharedPreferences.Editor oldEditor = oldSharedPref.edit();

--- a/src/android/FingerprintAuthenticationDialogFragment.java
+++ b/src/android/FingerprintAuthenticationDialogFragment.java
@@ -16,6 +16,7 @@
 
 package com.cordova.plugin.android.fingerprintauth;
 
+import android.app.Activity;
 import android.app.DialogFragment;
 import android.app.KeyguardManager;
 import android.content.Context;
@@ -33,6 +34,8 @@ import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.Toast;
+
+import org.apache.cordova.CordovaInterface;
 
 /**
  * A dialog which uses fingerprint APIs to authenticate the user, and falls back to password
@@ -52,7 +55,7 @@ public class FingerprintAuthenticationDialogFragment extends DialogFragment
     private KeyguardManager mKeyguardManager;
     private FingerprintManager.CryptoObject mCryptoObject;
     private FingerprintUiHelper mFingerprintUiHelper;
-    private FingerprintAuth mFingerPrintAuth;
+    private FingerprintAuthAux mFingerPrintAuth;
     FingerprintUiHelper.FingerprintUiHelperBuilder mFingerprintUiHelperBuilder;
 
     public FingerprintAuthenticationDialogFragment() {
@@ -180,7 +183,7 @@ public class FingerprintAuthenticationDialogFragment extends DialogFragment
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         if (requestCode == REQUEST_CODE_CONFIRM_DEVICE_CREDENTIALS) {
             // Challenge completed, proceed with using cipher
-            if (resultCode == getActivity().RESULT_OK) {
+            if (resultCode == Activity.RESULT_OK) {
                 mFingerPrintAuth.onAuthenticated(false /* used backup */);
             } else {
                 // The user canceled or didn’t complete the lock screen
@@ -210,11 +213,11 @@ public class FingerprintAuthenticationDialogFragment extends DialogFragment
         FingerprintAuth.onCancelled();
     }
 
-    public FingerprintAuth getmFingerPrintAuth() {
+    public FingerprintAuthAux getmFingerPrintAuth() {
         return mFingerPrintAuth;
     }
 
-    public void setmFingerPrintAuth(FingerprintAuth mFingerPrintAuth) {
+    public void setmFingerPrintAuth(FingerprintAuthAux mFingerPrintAuth) {
         this.mFingerPrintAuth = mFingerPrintAuth;
     }
 

--- a/src/ios/TouchID.h
+++ b/src/ios/TouchID.h
@@ -36,5 +36,4 @@
 - (void) delete:(CDVInvokedUrlCommand*)command;
 - (void) setLocale:(CDVInvokedUrlCommand*)command;
 
-
 @end

--- a/src/ios/TouchID.m
+++ b/src/ios/TouchID.m
@@ -22,12 +22,6 @@
 #include <sys/sysctl.h>
 #import <Cordova/CDV.h>
 
-#define SYSTEM_VERSION_EQUAL_TO(v)                  ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] == NSOrderedSame)
-#define SYSTEM_VERSION_GREATER_THAN(v)              ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] == NSOrderedDescending)
-#define SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(v)  ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] != NSOrderedAscending)
-#define SYSTEM_VERSION_LESS_THAN(v)                 ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] == NSOrderedAscending)
-#define SYSTEM_VERSION_LESS_THAN_OR_EQUAL_TO(v)     ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] != NSOrderedDescending)
-
 @implementation TouchID
 
 - (void)isAvailable:(CDVInvokedUrlCommand*)command{
@@ -41,9 +35,7 @@
     
     if ([self.laContext canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:nil]) {
         NSString *biometryType = @"";
-
-        if(SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"11"))
-        {
+        if (@available(iOS 11.0, *)) {
             if (self.laContext.biometryType == LABiometryTypeFaceID) {
                 biometryType = @"face";
             }

--- a/src/ios/TouchID.m
+++ b/src/ios/TouchID.m
@@ -26,14 +26,26 @@
 
 - (void)isAvailable:(CDVInvokedUrlCommand*)command{
     self.laContext = [[LAContext alloc] init];
-    BOOL touchIDAvailable = [self.laContext canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:nil];
+    NSError *error;
+    BOOL touchIDAvailable = [self.laContext canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&error];
     if(touchIDAvailable){
         CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
     }
     else{
-        CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString: @"Touch ID not available"];
-        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+        if(error)
+        {
+            //If an error is returned from LA Context (should always be true in this situation)
+            NSDictionary *errorDictionary = @{@"OS":@"iOS",@"ErrorCode":[NSString stringWithFormat:@"%li", (long)error.code],@"ErrorMessage":error.localizedDescription};
+            CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:errorDictionary];
+            [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+        }
+        else
+        {
+            //Should never come to this, but we treat it anyway
+            CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString: @"Touch ID not available"];
+            [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+        }
     }
 }
 
@@ -105,7 +117,8 @@
 
     BOOL hasLoginKey = [[NSUserDefaults standardUserDefaults] boolForKey:self.TAG];
     if(hasLoginKey){
-        BOOL touchIDAvailable = [self.laContext canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:nil];
+        NSError * error;
+        BOOL touchIDAvailable = [self.laContext canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&error];
 
         if(touchIDAvailable){
             [self.laContext evaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics localizedReason:message reply:^(BOOL success, NSError *error) {
@@ -116,17 +129,29 @@
                     CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString: password];
                     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
                 }
-                if(error != nil) {
-                    CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString: [NSString stringWithFormat:@"%li", error.code]];
-                    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
-                }
+                    if(error != nil) {
+                        NSDictionary *errorDictionary = @{@"OS":@"iOS",@"ErrorCode":[NSString stringWithFormat:@"%li", (long)error.code],@"ErrorMessage":error.localizedDescription};
+                        CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:errorDictionary];
+                        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+                    }
                 });
             }];
 
         }
         else{
-            CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString: @"-1"];
-            [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+            if(error)
+            {
+                //If an error is returned from LA Context (should always be true in this situation)
+                NSDictionary *errorDictionary = @{@"OS":@"iOS",@"ErrorCode":[NSString stringWithFormat:@"%li", (long)error.code],@"ErrorMessage":error.localizedDescription};
+                CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:errorDictionary];
+                [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+            }
+            else
+            {
+                //Should never come to this, but we treat it anyway
+                CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString: @"Touch ID not available"];
+                [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+            }
         }
     }
     else{

--- a/src/ios/TouchID.m
+++ b/src/ios/TouchID.m
@@ -22,6 +22,12 @@
 #include <sys/sysctl.h>
 #import <Cordova/CDV.h>
 
+#define SYSTEM_VERSION_EQUAL_TO(v)                  ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] == NSOrderedSame)
+#define SYSTEM_VERSION_GREATER_THAN(v)              ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] == NSOrderedDescending)
+#define SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(v)  ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] != NSOrderedAscending)
+#define SYSTEM_VERSION_LESS_THAN(v)                 ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] == NSOrderedAscending)
+#define SYSTEM_VERSION_LESS_THAN_OR_EQUAL_TO(v)     ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] != NSOrderedDescending)
+
 @implementation TouchID
 
 - (void)isAvailable:(CDVInvokedUrlCommand*)command{
@@ -35,7 +41,9 @@
     
     if ([self.laContext canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:nil]) {
         NSString *biometryType = @"";
-        if (@available(iOS 11.0, *)) {
+
+        if(SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"11"))
+        {
             if (self.laContext.biometryType == LABiometryTypeFaceID) {
                 biometryType = @"face";
             }

--- a/src/ios/TouchID.m
+++ b/src/ios/TouchID.m
@@ -25,27 +25,34 @@
 @implementation TouchID
 
 - (void)isAvailable:(CDVInvokedUrlCommand*)command{
-    self.laContext = [[LAContext alloc] init];
-    NSError *error;
-    BOOL touchIDAvailable = [self.laContext canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&error];
-    if(touchIDAvailable){
-        CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+    if (NSClassFromString(@"LAContext") == NULL) {
+        CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+        return;
     }
-    else{
-        if(error)
-        {
-            //If an error is returned from LA Context (should always be true in this situation)
-            NSDictionary *errorDictionary = @{@"OS":@"iOS",@"ErrorCode":[NSString stringWithFormat:@"%li", (long)error.code],@"ErrorMessage":error.localizedDescription};
-            CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:errorDictionary];
+    
+    self.laContext = [[LAContext alloc] init];
+    
+    if ([self.laContext canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:nil]) {
+        NSString *biometryType = @"";
+        if (@available(iOS 11.0, *)) {
+            if (self.laContext.biometryType == LABiometryTypeFaceID) {
+                biometryType = @"face";
+            }
+            else {
+                biometryType = @"touch";
+            }
+            CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:biometryType];
             [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
         }
-        else
-        {
-            //Should never come to this, but we treat it anyway
-            CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString: @"Touch ID not available"];
+        else {
+            CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString: @"touch"];
             [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
         }
+    }
+    else {
+        CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString: @"Touch ID not available"];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
     }
 }
 

--- a/www/touchid.js
+++ b/www/touchid.js
@@ -19,7 +19,11 @@ var touchid = {
 	},
 	setLocale: function(locale,successCallback, errorCallback){
 		exec(successCallback, errorCallback, "TouchID", "setLocale", [locale]);
-	}
+	},
+	move: function(key, packageName,successCallback, errorCallback){
+    	exec(successCallback, errorCallback, "TouchID", "move", [key,packageName]);
+    }
+
 };
 
 module.exports = touchid;

--- a/www/touchid.js
+++ b/www/touchid.js
@@ -5,8 +5,8 @@ var touchid = {
 	isAvailable: function(successCallback, errorCallback){
 		exec(successCallback, errorCallback, "TouchID", "isAvailable", []);
 	},
-	save: function(key,password, successCallback, errorCallback) {
-		exec(successCallback, errorCallback, "TouchID", "save", [key,password]);
+	save: function(key,password, userAuthenticationRequired, successCallback, errorCallback) {
+		exec(successCallback, errorCallback, "TouchID", "save", [key,password, userAuthenticationRequired]);
 	},
 	verify: function(key,message,successCallback, errorCallback){
 		exec(successCallback, errorCallback, "TouchID", "verify", [key,message]);


### PR DESCRIPTION
Added error returns for isAvailable and verify functions to allow callers to be able to go into different flows regarding touch ID unavalability.

Android:
Added option for user authentication required as some scenarios may not use it, defaults to true to keep compatibility with previous implementation.
Altered save so you can choose to save without fingerprint (same behavior as iOS).
isAvailable and verify functions return the same error codes as iOS to keep consistency for caller.