### PR TITLE
Allow to define custom dialog titles using javascript API

### DIFF
--- a/src/android/FingerprintAuthenticationDialogFragment.java
+++ b/src/android/FingerprintAuthenticationDialogFragment.java
@@ -68,7 +68,7 @@ public class FingerprintAuthenticationDialogFragment extends DialogFragment
 
         mKeyguardManager = (KeyguardManager) getContext().getSystemService(Context.KEYGUARD_SERVICE);
         mFingerprintUiHelperBuilder = new FingerprintUiHelper.FingerprintUiHelperBuilder(
-                getContext(), getContext().getSystemService(FingerprintManager.class));
+                getContext(), getContext().getSystemService(FingerprintManager.class), getArguments());
 
     }
 
@@ -77,22 +77,24 @@ public class FingerprintAuthenticationDialogFragment extends DialogFragment
                              Bundle savedInstanceState) {
         Bundle args = getArguments();
         int dialogMode = args.getInt("dialogMode");
-        String message = args.getString("dialogMessage");
         Log.d(TAG, "dialogMode: " + dialogMode);
 
-        int fingerprint_auth_dialog_title_id = getResources()
-                .getIdentifier("fingerprint_auth_dialog_title", "string",
-                        FingerprintAuth.packageName);
-        getDialog().setTitle(getString(fingerprint_auth_dialog_title_id));
-        int fingerprint_dialog_container_id = getResources()
-                .getIdentifier("fingerprint_dialog_container", "layout",
-                        FingerprintAuth.packageName);
-        View v = inflater.inflate(fingerprint_dialog_container_id, container, false);
-        int cancel_button_id = getResources()
-                .getIdentifier("cancel_button", "id", FingerprintAuth.packageName);
+        String title = args.getString("dialogTitle");
+        if (title == null) {
+            int fingerprint_auth_dialog_title_id = getResources()
+                    .getIdentifier("fingerprint_auth_dialog_title", "string", FingerprintAuth.packageName);
+            title = getString(fingerprint_auth_dialog_title_id);
+        }
+        getDialog().setTitle(title);
 
-        TextView description =  (TextView) v.findViewById(getResources()
-                .getIdentifier("fingerprint_description", "id", FingerprintAuth.packageName));
+
+        int fingerprint_dialog_container_id = getResources()
+                .getIdentifier("fingerprint_dialog_container", "layout", FingerprintAuth.packageName);
+        View v = inflater.inflate(fingerprint_dialog_container_id, container, false);
+        int cancel_button_id = getResources().getIdentifier("cancel_button", "id", FingerprintAuth.packageName);
+
+        String message = args.getString("dialogMessage");
+        TextView description = (TextView) v.findViewById(getResources().getIdentifier("fingerprint_description", "id", FingerprintAuth.packageName));
         description.setText(message);
         mCancelButton = (Button) v.findViewById(cancel_button_id);
         mCancelButton.setOnClickListener(new View.OnClickListener() {
@@ -102,6 +104,15 @@ public class FingerprintAuthenticationDialogFragment extends DialogFragment
                 dismiss();
             }
         });
+
+        TextView statusView = (TextView) v.findViewById(getResources().getIdentifier("fingerprint_status", "id", FingerprintAuth.packageName));
+        String hint = args.getString("dialogHint");
+        if (hint == null) {
+            int fingerprint_auth_dialog_hint_id = getResources().getIdentifier("fingerprint_hint", "string", FingerprintAuth.packageName);
+            hint = getString(fingerprint_auth_dialog_hint_id);
+        }
+        statusView.setText(hint);
+
 
         int fingerprint_container_id = getResources()
                 .getIdentifier("fingerprint_container", "id", FingerprintAuth.packageName);
@@ -157,11 +168,16 @@ public class FingerprintAuthenticationDialogFragment extends DialogFragment
 
 
     private void updateStage() {
-        int cancel_id = getResources()
-                .getIdentifier("cancel", "string", FingerprintAuth.packageName);
         switch (mStage) {
             case FINGERPRINT:
-                mCancelButton.setText(cancel_id);
+                Bundle args = getArguments();
+                if (args.containsKey("dialogCancel") && args.getString("dialogCancel") != null) {
+                    mCancelButton.setText(args.getString("dialogCancel"));
+                } else {
+                    int cancel_id = getResources().getIdentifier("cancel", "string", FingerprintAuth.packageName);
+                    mCancelButton.setText(cancel_id);
+                }
+
                 mFingerprintContent.setVisibility(View.VISIBLE);
                 break;
         }

--- a/src/android/FingerprintUiHelper.java
+++ b/src/android/FingerprintUiHelper.java
@@ -19,6 +19,7 @@ package com.cordova.plugin.android.fingerprintauth;
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.hardware.fingerprint.FingerprintManager;
+import android.os.Bundle;
 import android.os.CancellationSignal;
 import android.widget.ImageView;
 import android.widget.TextView;
@@ -38,6 +39,7 @@ public class FingerprintUiHelper extends FingerprintManager.AuthenticationCallba
     private final ImageView mIcon;
     private final TextView mErrorTextView;
     private final Callback mCallback;
+    private final Bundle mOptions;
     private CancellationSignal mCancellationSignal;
 
     boolean mSelfCancelled;
@@ -49,15 +51,16 @@ public class FingerprintUiHelper extends FingerprintManager.AuthenticationCallba
     public static class FingerprintUiHelperBuilder {
         private final FingerprintManager mFingerPrintManager;
         private final Context mContext;
+        private final Bundle mOptions;
 
-        public FingerprintUiHelperBuilder(Context context, FingerprintManager fingerprintManager) {
+        public FingerprintUiHelperBuilder(Context context, FingerprintManager fingerprintManager, Bundle options) {
             mFingerPrintManager = fingerprintManager;
             mContext = context;
+            mOptions = options;
         }
 
         public FingerprintUiHelper build(ImageView icon, TextView errorTextView, Callback callback) {
-            return new FingerprintUiHelper(mContext, mFingerPrintManager, icon, errorTextView,
-                    callback);
+            return new FingerprintUiHelper(mContext, mFingerPrintManager, mOptions, icon, errorTextView, callback);
         }
     }
 
@@ -65,9 +68,10 @@ public class FingerprintUiHelper extends FingerprintManager.AuthenticationCallba
      * Constructor for {@link FingerprintUiHelper}. This method is expected to be called from
      * only the {@link FingerprintUiHelperBuilder} class.
      */
-    private FingerprintUiHelper(Context context, FingerprintManager fingerprintManager,
-            ImageView icon, TextView errorTextView, Callback callback) {
+    private FingerprintUiHelper(Context context, FingerprintManager fingerprintManager, Bundle options,
+                                ImageView icon, TextView errorTextView, Callback callback) {
         mFingerprintManager = fingerprintManager;
+        mOptions = options;
         mIcon = icon;
         mErrorTextView = errorTextView;
         mCallback = callback;
@@ -121,10 +125,12 @@ public class FingerprintUiHelper extends FingerprintManager.AuthenticationCallba
 
     @Override
     public void onAuthenticationFailed() {
-        int fingerprint_not_recognized_id = mContext.getResources()
-                .getIdentifier("fingerprint_not_recognized", "string", FingerprintAuth.packageName);
-        showError(mIcon.getResources().getString(
-                fingerprint_not_recognized_id));
+        String dialogStatusNotRecognized = mOptions.getString("dialogStatusNotRecognized");
+        if (dialogStatusNotRecognized == null) {
+            int fingerprint_not_recognized_id = mContext.getResources().getIdentifier("fingerprint_not_recognized", "string", FingerprintAuth.packageName);
+            dialogStatusNotRecognized = mIcon.getResources().getString(fingerprint_not_recognized_id);
+        }
+        showError(dialogStatusNotRecognized);
     }
 
     @Override
@@ -137,10 +143,13 @@ public class FingerprintUiHelper extends FingerprintManager.AuthenticationCallba
                 .getIdentifier("kc_success_color", "color", FingerprintAuth.packageName);
         mErrorTextView.setTextColor(
                 mErrorTextView.getResources().getColor(success_color_id, null));
-        int fingerprint_success_id = mContext.getResources()
-                .getIdentifier("fingerprint_success", "string", FingerprintAuth.packageName);
-        mErrorTextView.setText(
-                mErrorTextView.getResources().getString(fingerprint_success_id));
+
+        String dialogStatusSuccess = mOptions.getString("dialogStatusSuccess");
+        if (dialogStatusSuccess == null) {
+            int fingerprint_success_id = mContext.getResources().getIdentifier("fingerprint_success", "string", FingerprintAuth.packageName);
+            dialogStatusSuccess = mErrorTextView.getResources().getString(fingerprint_success_id);
+        }
+        mErrorTextView.setText(dialogStatusSuccess);
         mIcon.postDelayed(new Runnable() {
             @Override
             public void run() {
@@ -165,16 +174,16 @@ public class FingerprintUiHelper extends FingerprintManager.AuthenticationCallba
     Runnable mResetErrorTextRunnable = new Runnable() {
         @Override
         public void run() {
-            int hint_color_id = mContext.getResources()
-                    .getIdentifier("kc_hint_color", "color", FingerprintAuth.packageName);
-            mErrorTextView.setTextColor(
-                    mErrorTextView.getResources().getColor(hint_color_id, null));
-            int fingerprint_hint_id = mContext.getResources()
-                    .getIdentifier("fingerprint_hint", "string", FingerprintAuth.packageName);
-            mErrorTextView.setText(
-                    mErrorTextView.getResources().getString(fingerprint_hint_id));
-            int ic_fp_40px_id = mContext.getResources()
-                    .getIdentifier("ic_fp_40px", "drawable", FingerprintAuth.packageName);
+            int hint_color_id = mContext.getResources().getIdentifier("kc_hint_color", "color", FingerprintAuth.packageName);
+            mErrorTextView.setTextColor(mErrorTextView.getResources().getColor(hint_color_id, null));
+
+            String dialogHint = mOptions.getString("dialogHint");
+            if (dialogHint == null) {
+                int fingerprint_hint_id = mContext.getResources().getIdentifier("fingerprint_hint", "string", FingerprintAuth.packageName);
+                dialogHint = mErrorTextView.getResources().getString(fingerprint_hint_id);
+            }
+            mErrorTextView.setText(dialogHint);
+            int ic_fp_40px_id = mContext.getResources().getIdentifier("ic_fp_40px", "drawable", FingerprintAuth.packageName);
             mIcon.setImageResource(ic_fp_40px_id);
         }
     };

--- a/src/ios/TouchID.m
+++ b/src/ios/TouchID.m
@@ -56,8 +56,15 @@
 }
 
 - (void)save:(CDVInvokedUrlCommand*)command{
-	 	self.TAG = (NSString*)[command.arguments objectAtIndex:0];
-    NSString* password = (NSString*)[command.arguments objectAtIndex:1];
+    self.TAG = (NSString*)[command.arguments objectAtIndex:0];
+    NSObject* o = [command.arguments objectAtIndex:1];
+    NSString* password;
+    if ([o isKindOfClass:[NSDictionary class]]) {
+        password = [((NSDictionary*) o) objectForKey:@"password"];
+    }
+    else {
+        password = (NSString *) o;
+    }
     @try {
         self.MyKeychainWrapper = [[KeychainWrapper alloc]init];
         [self.MyKeychainWrapper mySetObject:password forKey:(__bridge id)(kSecValueData)];
@@ -98,11 +105,20 @@
 }
 
 -(void)verify:(CDVInvokedUrlCommand*)command{
-	 	self.TAG = (NSString*)[command.arguments objectAtIndex:0];
-	  NSString* message = (NSString*)[command.arguments objectAtIndex:1];
+    self.TAG = (NSString*)[command.arguments objectAtIndex:0];
     self.laContext = [[LAContext alloc] init];
     self.MyKeychainWrapper = [[KeychainWrapper alloc]init];
 
+    NSObject* o = [command.arguments objectAtIndex:1];
+    NSString* message;
+    if ([o isKindOfClass:[NSDictionary class]]) {
+        message = [((NSDictionary*) o) objectForKey:@"message"];
+    }
+    else {
+        message = (NSString *) o;
+    }
+    
+    
     BOOL hasLoginKey = [[NSUserDefaults standardUserDefaults] boolForKey:self.TAG];
     if(hasLoginKey){
         BOOL touchIDAvailable = [self.laContext canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:nil];
@@ -113,12 +129,12 @@
 
                 if(success){
                     NSString *password = [self.MyKeychainWrapper myObjectForKey:@"v_Data"];
-                    CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString: password];
+									  CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString: password];
                     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
                 }
                 if(error != nil) {
-                    CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString: [NSString stringWithFormat:@"%li", error.code]];
-                    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+										CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString: [NSString stringWithFormat:@"%li", error.code]];
+										[self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
                 }
                 });
             }];


### PR DESCRIPTION
I would like to customize and localize dialog messages for .save and .verify methods.
So this changes allow to provide second argument as string (as in previous versions) or object with custom titles:

/**
 * @param {(string|Object)} options - string with password or object with properties: [password (requried), dialogTitle, dialogMessage, dialogHint, dialogCancel, dialogStatusSuccess, dialogStatusNotRecognized]
 */
save: function(key, options, successCallback, errorCallback) 

/**
 * @param {(string|Object)} options - string with dialog message or object with properties: [password (requried), dialogTitle, dialogMessage, dialogHint, dialogCancel, dialogStatusSuccess, dialogStatusNotRecognized]
 */
verify: function(key,options,successCallback, errorCallback)

If some properties are not defined then default messages will be using.
Fully compatible with previous version