### PR TITLE
Allow to set message for the "save" dialog android devices

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "cordova-plugin-keychain-touch-id",
-  "version": "3.2.1",
+  "name": "@saritasa/cordova-plugin-keychain-touch-id",
+  "version": "3.3.0",
   "description": "Scan the fingerprint of your user with the TouchID sensor (iPhone 5S, iPhone 6(S), ..) and control a key in the Keychain",
   "cordova": {
     "id": "cordova-plugin-keychain-touch-id",
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sjhoeksma/cordova-plugin-keychain-touch-id.git"
+    "url": "https://github.com/Saritasa/cordova-plugin-keychain-touch-id.git"
   },
   "keywords": [
     "TouchID",
@@ -22,18 +22,15 @@
     "ecosystem:cordova",
     "cordova-ios"
   ],
-  "engines": [
-    {
-      "name": "cordova",
-      "version": ">=3.0.0"
-    }
-  ],
+  "engines": {
+    "cordova": ">=3.0.0"
+  },
   "author": "S.J.Hoeksma",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/sjhoeksma/cordova-plugin-keychain-touch-id/issues"
+    "url": "https://github.com/Saritasa/cordova-plugin-keychain-touch-id/issues"
   },
-  "homepage": "https://github.com/sjhoeksma/cordova-plugin-keychain-touch-id#readme",
+  "homepage": "https://github.com/Saritasa/cordova-plugin-keychain-touch-id#readme",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/plugin.xml
+++ b/plugin.xml
@@ -23,6 +23,11 @@
                 <param name="ios-package" value="TouchID"/>
             </feature>
         </config-file>
+        <!-- Usage description of Face ID for iOS 11+ -->
+        <preference name="FACEID_USAGE_DESCRIPTION" default=" " />
+        <config-file target="*-Info.plist" parent="NSFaceIDUsageDescription">
+            <string>$FACEID_USAGE_DESCRIPTION</string>
+        </config-file>
         <header-file src="src/ios/KeychainWrapper.h" />
         <source-file src="src/ios/KeychainWrapper.m" />
         <header-file src="src/ios/TouchID.h" />

--- a/readme.md
+++ b/readme.md
@@ -109,8 +109,9 @@ if (window.plugins) {
     });
 }
 
+// NOTE: Message will show only on android. iOS does not request touchId for save.
 if (window.plugins) {
-    window.plugins.touchid.save("MyKey", "My Password", function() {
+    window.plugins.touchid.save("MyKey", "My Password", "My Message", function() {
         alert("Password saved");
     });
 }

--- a/src/android/FingerprintAuth.java
+++ b/src/android/FingerprintAuth.java
@@ -156,6 +156,7 @@ public class FingerprintAuth extends CordovaPlugin {
         if (action.equals("save")) {
             final String key = args.getString(0);
             final String password = args.getString(1);
+            final String message = args.getString(2);
 
             if (isFingerprintAuthAvailable()) {
                 SecretKey secretKey = getSecretKey();
@@ -167,7 +168,7 @@ public class FingerprintAuth extends CordovaPlugin {
                 }
                 mKeyID = key;
                 mToEncrypt = password;
-                showFingerprintDialog(Cipher.ENCRYPT_MODE,null);
+                showFingerprintDialog(Cipher.ENCRYPT_MODE,message);
 
                 return true;
             } else {

--- a/www/touchid.js
+++ b/www/touchid.js
@@ -1,23 +1,23 @@
 var argscheck = require('cordova/argscheck'),
-               exec = require('cordova/exec');
+	exec = require('cordova/exec');
 
 var touchid = {
-	isAvailable: function(successCallback, errorCallback){
+	isAvailable: function (successCallback, errorCallback) {
 		exec(successCallback, errorCallback, "TouchID", "isAvailable", []);
 	},
-	save: function(key,password, successCallback, errorCallback) {
-		exec(successCallback, errorCallback, "TouchID", "save", [key,password]);
+	save: function (key, password, message, successCallback, errorCallback) {
+		exec(successCallback, errorCallback, "TouchID", "save", [key, password, message]);
 	},
-	verify: function(key,message,successCallback, errorCallback){
-		exec(successCallback, errorCallback, "TouchID", "verify", [key,message]);
+	verify: function (key, message, successCallback, errorCallback) {
+		exec(successCallback, errorCallback, "TouchID", "verify", [key, message]);
 	},
-	has: function(key,successCallback, errorCallback){
+	has: function (key, successCallback, errorCallback) {
 		exec(successCallback, errorCallback, "TouchID", "has", [key]);
 	},
-	delete: function(key,successCallback, errorCallback){
+	delete: function (key, successCallback, errorCallback) {
 		exec(successCallback, errorCallback, "TouchID", "delete", [key]);
 	},
-	setLocale: function(locale,successCallback, errorCallback){
+	setLocale: function (locale, successCallback, errorCallback) {
 		exec(successCallback, errorCallback, "TouchID", "setLocale", [locale]);
 	}
 };


### PR DESCRIPTION
Added the "message" parameter for method "save" on android devices.
iOS does not show fingerprint dialog for the save action