### PR TITLE
Handle KeyStoreException in Android 8.0

### DIFF
--- a/src/android/FingerprintAuth.java
+++ b/src/android/FingerprintAuth.java
@@ -445,8 +445,21 @@ public class FingerprintAuth extends CordovaPlugin {
                     " BadPaddingException:  " + e.getMessage();
             Log.e(TAG, errorMessage);
         } catch (IllegalBlockSizeException e) {
+            String message = e.getMessage();
+            String exception = e.getClass().getSimpleName();
+            if (message == null) {
+                Throwable cause = e.getCause();
+                if (cause != null) {
+                    message = cause.getMessage();
+                    exception = cause.getClass().getSimpleName();
+                }
+            }
             errorMessage = "Failed to encrypt the data with the generated key: " +
-                    "IllegalBlockSizeException: " + e.getMessage();
+                    exception + ": " + message;
+            if (message == "Key user not authenticated") {
+                removePermanentlyInvalidatedKey();
+                errorMessage = "KeyPermanentlyInvalidatedException";
+            }
             Log.e(TAG, errorMessage);
         }
 


### PR DESCRIPTION
This exception is thrown in "verify" on Android 8.0 if new fingerprints were enrolled after "save" has been called. On Android 8.1 KeyPermanentlyInvalidatedException is thrown in the same scenario (but already in "has"), therefore I'm handling it the same - i.e. deleting the key so that it will be recreated on next call.

When the application receives this error (KeyPermanentlyInvalidatedException), it should reinitialize the fingerprint usage - the user will have to reenter the password and agree to store it using the fingerprint.